### PR TITLE
[Feat/#1] App Coordinator / Root Reducer 구현

### DIFF
--- a/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Module.swift
+++ b/Plugins/DependencyPlugin/ProjectDescriptionHelpers/Module.swift
@@ -22,6 +22,8 @@ public extension ModulePath {
 public extension ModulePath {
     enum Feature: String, CaseIterable {
         public static let name: String = "Feature"
+        case AppCoordinator
+        case Tab
         case Splash
         case Common
         case Onboarding

--- a/Projects/App/Sources/TtokdogApp.swift
+++ b/Projects/App/Sources/TtokdogApp.swift
@@ -1,10 +1,17 @@
 import SwiftUI
+import ComposableArchitecture
+import FeatureAppCoordinator
 
 @main
 struct TtokdogApp: App {
+    let store = Store(
+        initialState: AppFeature.State(),
+        reducer: { AppFeature() }
+    )
+
     var body: some Scene {
         WindowGroup {
-            Text("똑독")
+            AppView(store: store)
         }
     }
 }

--- a/Projects/Feature/AppCoordinator/Example/Sources/AppCoordinatorExampleApp.swift
+++ b/Projects/Feature/AppCoordinator/Example/Sources/AppCoordinatorExampleApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import ComposableArchitecture
+import FeatureAppCoordinator
+
+@main
+struct AppCoordinatorExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            AppView(
+                store: .init(
+                    initialState: AppFeature.State(),
+                    reducer: { AppFeature() }
+                )
+            )
+        }
+    }
+}

--- a/Projects/Feature/AppCoordinator/Project.swift
+++ b/Projects/Feature/AppCoordinator/Project.swift
@@ -1,0 +1,17 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.makeModule(
+    name: ModulePath.Feature.name + ModulePath.Feature.AppCoordinator.rawValue,
+    targets: [
+        .feature(sources: .AppCoordinator, target: .init(dependencies: [
+            .feature(sources: .Tab),
+            .feature(sources: .Splash),
+            .feature(sources: .Onboarding),
+            .shared(sources: .ThirdParty),
+        ])),
+        .feature(tests: .AppCoordinator, target: .init(dependencies: [.feature(sources: .AppCoordinator)])),
+        .feature(example: .AppCoordinator, target: .init(dependencies: [.feature(sources: .AppCoordinator)])),
+    ]
+)

--- a/Projects/Feature/AppCoordinator/Sources/AppFeature.swift
+++ b/Projects/Feature/AppCoordinator/Sources/AppFeature.swift
@@ -1,0 +1,54 @@
+import Foundation
+import ComposableArchitecture
+import FeatureSplash
+import FeatureOnboarding
+import FeatureTab
+
+@Reducer
+public struct AppFeature: Reducer {
+
+    @ObservableState
+    public enum State: Equatable {
+        case splash(SplashFeature.State)
+        case onboarding(OnboardingFeature.State)
+        case tab(TabFeature.State)
+
+        public init() {
+            self = .splash(SplashFeature.State())
+        }
+    }
+
+    public init() {}
+
+    public enum Action {
+        case splash(SplashFeature.Action)
+        case onboarding(OnboardingFeature.Action)
+        case tab(TabFeature.Action)
+    }
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case let .splash(.delegate(.splashCompleted(isAuthenticated))):
+                if isAuthenticated {
+                    state = .tab(TabFeature.State())
+                } else {
+                    state = .onboarding(OnboardingFeature.State())
+                }
+                return .none
+
+            case .splash, .onboarding, .tab:
+                return .none
+            }
+        }
+        .ifCaseLet(\.splash, action: \.splash) {
+            SplashFeature()
+        }
+        .ifCaseLet(\.onboarding, action: \.onboarding) {
+            OnboardingFeature()
+        }
+        .ifCaseLet(\.tab, action: \.tab) {
+            TabFeature()
+        }
+    }
+}

--- a/Projects/Feature/AppCoordinator/Sources/AppView.swift
+++ b/Projects/Feature/AppCoordinator/Sources/AppView.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import ComposableArchitecture
+import FeatureSplash
+import FeatureOnboarding
+import FeatureTab
+
+public struct AppView: View {
+    @Bindable public var store: StoreOf<AppFeature>
+
+    public init(store: StoreOf<AppFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        switch store.state {
+        case .splash:
+            if let splashStore = store.scope(state: \.splash, action: \.splash) {
+                SplashView(store: splashStore)
+            }
+
+        case .onboarding:
+            if let onboardingStore = store.scope(state: \.onboarding, action: \.onboarding) {
+                OnboardingView(store: onboardingStore)
+            }
+
+        case .tab:
+            if let tabStore = store.scope(state: \.tab, action: \.tab) {
+                TabBarView(store: tabStore)
+            }
+        }
+    }
+}
+
+#Preview {
+    AppView(
+        store: .init(
+            initialState: AppFeature.State(),
+            reducer: { AppFeature() }
+        )
+    )
+}

--- a/Projects/Feature/AppCoordinator/Tests/Sources/AppCoordinatorTests.swift
+++ b/Projects/Feature/AppCoordinator/Tests/Sources/AppCoordinatorTests.swift
@@ -1,0 +1,10 @@
+import Testing
+import FeatureSplash
+@testable import FeatureAppCoordinator
+
+struct AppCoordinatorTests {
+    @Test func initialStateIsSplash() {
+        let state = AppFeature.State()
+        #expect(state == .splash(SplashFeature.State()))
+    }
+}

--- a/Projects/Feature/Home/Example/Sources/HomeExampleApp.swift
+++ b/Projects/Feature/Home/Example/Sources/HomeExampleApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import ComposableArchitecture
+import FeatureHome
+
+@main
+struct HomeExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            HomeView(
+                store: .init(
+                    initialState: HomeFeature.State(),
+                    reducer: { HomeFeature() }
+                )
+            )
+        }
+    }
+}

--- a/Projects/Feature/Home/Project.swift
+++ b/Projects/Feature/Home/Project.swift
@@ -11,5 +11,6 @@ let project = Project.makeModule(
             .shared(sources: .ThirdParty),
         ])),
         .feature(tests: .Home, target: .init(dependencies: [.feature(sources: .Home)])),
+        .feature(example: .Home, target: .init(dependencies: [.feature(sources: .Home)])),
     ]
 )

--- a/Projects/Feature/Map/Example/Sources/MapExampleApp.swift
+++ b/Projects/Feature/Map/Example/Sources/MapExampleApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import ComposableArchitecture
+import FeatureMap
+
+@main
+struct MapExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            MapView(
+                store: .init(
+                    initialState: MapFeature.State(),
+                    reducer: { MapFeature() }
+                )
+            )
+        }
+    }
+}

--- a/Projects/Feature/Map/Project.swift
+++ b/Projects/Feature/Map/Project.swift
@@ -11,5 +11,6 @@ let project = Project.makeModule(
             .shared(sources: .ThirdParty),
         ])),
         .feature(tests: .Map, target: .init(dependencies: [.feature(sources: .Map)])),
+        .feature(example: .Map, target: .init(dependencies: [.feature(sources: .Map)])),
     ]
 )

--- a/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
+++ b/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import ComposableArchitecture
+import FeatureOnboarding
+
+@main
+struct OnboardingExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            OnboardingView(
+                store: .init(
+                    initialState: OnboardingFeature.State(),
+                    reducer: { OnboardingFeature() }
+                )
+            )
+        }
+    }
+}

--- a/Projects/Feature/Onboarding/Project.swift
+++ b/Projects/Feature/Onboarding/Project.swift
@@ -12,5 +12,6 @@ let project = Project.makeModule(
             .shared(sources: .ThirdPartyAuth),
         ])),
         .feature(tests: .Onboarding, target: .init(dependencies: [.feature(sources: .Onboarding)])),
+        .feature(example: .Onboarding, target: .init(dependencies: [.feature(sources: .Onboarding)])),
     ]
 )

--- a/Projects/Feature/Plan/Example/Sources/PlanExampleApp.swift
+++ b/Projects/Feature/Plan/Example/Sources/PlanExampleApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import ComposableArchitecture
+import FeaturePlan
+
+@main
+struct PlanExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            PlanView(
+                store: .init(
+                    initialState: PlanFeature.State(),
+                    reducer: { PlanFeature() }
+                )
+            )
+        }
+    }
+}

--- a/Projects/Feature/Plan/Project.swift
+++ b/Projects/Feature/Plan/Project.swift
@@ -11,5 +11,6 @@ let project = Project.makeModule(
             .shared(sources: .ThirdParty),
         ])),
         .feature(tests: .Plan, target: .init(dependencies: [.feature(sources: .Plan)])),
+        .feature(example: .Plan, target: .init(dependencies: [.feature(sources: .Plan)])),
     ]
 )

--- a/Projects/Feature/Profile/Example/Sources/ProfileExampleApp.swift
+++ b/Projects/Feature/Profile/Example/Sources/ProfileExampleApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import ComposableArchitecture
+import FeatureProfile
+
+@main
+struct ProfileExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ProfileView(
+                store: .init(
+                    initialState: ProfileFeature.State(),
+                    reducer: { ProfileFeature() }
+                )
+            )
+        }
+    }
+}

--- a/Projects/Feature/Profile/Project.swift
+++ b/Projects/Feature/Profile/Project.swift
@@ -11,5 +11,6 @@ let project = Project.makeModule(
             .shared(sources: .ThirdParty),
         ])),
         .feature(tests: .Profile, target: .init(dependencies: [.feature(sources: .Profile)])),
+        .feature(example: .Profile, target: .init(dependencies: [.feature(sources: .Profile)])),
     ]
 )

--- a/Projects/Feature/Project.swift
+++ b/Projects/Feature/Project.swift
@@ -6,6 +6,8 @@ let targets: [Target] = [
     .feature(target: .init(
         dependencies: [
             .domain,
+            .feature(sources: .AppCoordinator),
+            .feature(sources: .Tab),
             .feature(sources: .Splash),
             .feature(sources: .Common),
             .feature(sources: .Onboarding),

--- a/Projects/Feature/Splash/Example/Sources/SplashExampleApp.swift
+++ b/Projects/Feature/Splash/Example/Sources/SplashExampleApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import ComposableArchitecture
+import FeatureSplash
+
+@main
+struct SplashExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            SplashView(
+                store: .init(
+                    initialState: SplashFeature.State(),
+                    reducer: { SplashFeature() }
+                )
+            )
+        }
+    }
+}

--- a/Projects/Feature/Splash/Project.swift
+++ b/Projects/Feature/Splash/Project.swift
@@ -11,5 +11,6 @@ let project = Project.makeModule(
             .shared(sources: .ThirdParty),
         ])),
         .feature(tests: .Splash, target: .init(dependencies: [.feature(sources: .Splash)])),
+        .feature(example: .Splash, target: .init(dependencies: [.feature(sources: .Splash)])),
     ]
 )

--- a/Projects/Feature/Splash/Sources/SplashFeature.swift
+++ b/Projects/Feature/Splash/Sources/SplashFeature.swift
@@ -13,12 +13,22 @@ public struct SplashFeature: Reducer {
 
     public enum Action {
         case onAppear
+        case delegate(Delegate)
+
+        public enum Delegate {
+            case splashCompleted(isAuthenticated: Bool)
+        }
     }
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
             case .onAppear:
+                // TODO: 인증 상태 확인 로직 연결 (Domain 레이어)
+                // 현재는 스텁으로 미인증 상태를 반환
+                return .send(.delegate(.splashCompleted(isAuthenticated: false)))
+
+            case .delegate:
                 return .none
             }
         }

--- a/Projects/Feature/Tab/Example/Sources/TabExampleApp.swift
+++ b/Projects/Feature/Tab/Example/Sources/TabExampleApp.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import ComposableArchitecture
+import FeatureTab
+
+@main
+struct TabExampleApp: App {
+    var body: some Scene {
+        WindowGroup {
+            TabBarView(
+                store: .init(
+                    initialState: TabFeature.State(),
+                    reducer: { TabFeature() }
+                )
+            )
+        }
+    }
+}

--- a/Projects/Feature/Tab/Project.swift
+++ b/Projects/Feature/Tab/Project.swift
@@ -1,0 +1,19 @@
+import ProjectDescription
+import ProjectDescriptionHelpers
+import DependencyPlugin
+
+let project = Project.makeModule(
+    name: ModulePath.Feature.name + ModulePath.Feature.Tab.rawValue,
+    targets: [
+        .feature(sources: .Tab, target: .init(dependencies: [
+            .feature(sources: .Home),
+            .feature(sources: .Plan),
+            .feature(sources: .Map),
+            .feature(sources: .Profile),
+            .shared(sources: .DesignSystem),
+            .shared(sources: .ThirdParty),
+        ])),
+        .feature(tests: .Tab, target: .init(dependencies: [.feature(sources: .Tab)])),
+        .feature(example: .Tab, target: .init(dependencies: [.feature(sources: .Tab)])),
+    ]
+)

--- a/Projects/Feature/Tab/Sources/TabBarView.swift
+++ b/Projects/Feature/Tab/Sources/TabBarView.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+import ComposableArchitecture
+import FeatureHome
+import FeaturePlan
+import FeatureMap
+import FeatureProfile
+
+public struct TabBarView: View {
+    @Bindable public var store: StoreOf<TabFeature>
+
+    public init(store: StoreOf<TabFeature>) {
+        self.store = store
+    }
+
+    // TODO: 탭바 아이콘은 디자인 확정 후 DesignSystem 에셋으로 교체 예정
+    public var body: some View {
+        TabView(selection: $store.selectedTab.sending(\.tabSelected)) {
+            HomeView(store: store.scope(state: \.home, action: \.home))
+                .tag(TabFeature.Tab.home)
+                .tabItem {
+                    Label("홈", systemImage: "house")
+                }
+
+            PlanView(store: store.scope(state: \.plan, action: \.plan))
+                .tag(TabFeature.Tab.plan)
+                .tabItem {
+                    Label("댕플랜", systemImage: "calendar")
+                }
+
+            MapView(store: store.scope(state: \.map, action: \.map))
+                .tag(TabFeature.Tab.map)
+                .tabItem {
+                    Label("동네산책", systemImage: "map")
+                }
+
+            ProfileView(store: store.scope(state: \.profile, action: \.profile))
+                .tag(TabFeature.Tab.profile)
+                .tabItem {
+                    Label("My", systemImage: "person")
+                }
+        }
+    }
+}
+
+#Preview {
+    TabBarView(
+        store: .init(
+            initialState: TabFeature.State(),
+            reducer: { TabFeature() }
+        )
+    )
+}

--- a/Projects/Feature/Tab/Sources/TabFeature.swift
+++ b/Projects/Feature/Tab/Sources/TabFeature.swift
@@ -1,0 +1,64 @@
+import Foundation
+import ComposableArchitecture
+import FeatureHome
+import FeaturePlan
+import FeatureMap
+import FeatureProfile
+
+@Reducer
+public struct TabFeature: Reducer {
+
+    public enum Tab: String, Equatable, CaseIterable {
+        case home
+        case plan
+        case map
+        case profile
+    }
+
+    @ObservableState
+    public struct State: Equatable {
+        public var selectedTab: Tab = .home
+        public var home: HomeFeature.State = .init()
+        public var plan: PlanFeature.State = .init()
+        public var map: MapFeature.State = .init()
+        public var profile: ProfileFeature.State = .init()
+
+        public init() {}
+    }
+
+    public init() {}
+
+    public enum Action {
+        case tabSelected(Tab)
+        case home(HomeFeature.Action)
+        case plan(PlanFeature.Action)
+        case map(MapFeature.Action)
+        case profile(ProfileFeature.Action)
+    }
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case let .tabSelected(tab):
+                state.selectedTab = tab
+                return .none
+
+            case .home, .plan, .map, .profile:
+                return .none
+            }
+        }
+
+        Scope(state: \.home, action: \.home) {
+            HomeFeature()
+        }
+        Scope(state: \.plan, action: \.plan) {
+            PlanFeature()
+        }
+        Scope(state: \.map, action: \.map) {
+            MapFeature()
+        }
+        Scope(state: \.profile, action: \.profile) {
+            ProfileFeature()
+        }
+    }
+}

--- a/Projects/Feature/Tab/Tests/Sources/TabTests.swift
+++ b/Projects/Feature/Tab/Tests/Sources/TabTests.swift
@@ -1,0 +1,9 @@
+import Testing
+@testable import FeatureTab
+
+struct TabTests {
+    @Test func defaultTabIsHome() {
+        let state = TabFeature.State()
+        #expect(state.selectedTab == .home)
+    }
+}

--- a/Projects/Shared/DesignSystem/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Brand Colors/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Brand Colors/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Gradient System/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Gradient System/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Neutral Grayscale/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Neutral Grayscale/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Semantic System/Contents.json
+++ b/Projects/Shared/DesignSystem/Resources/Assets.xcassets/Semantic System/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}


### PR DESCRIPTION
## Related Issue

- #1

## Background

앱 전체 네비게이션 흐름을 관리하는 AppFeature(Root Reducer)와 TabFeature를 구현합니다.
Splash → 인증 확인 → Onboarding 또는 TabBar(Home/Plan/Map/Profile) 흐름입니다.

## Contents

### AppFeature (Root Reducer)
```swift
@ObservableState
public enum State: Equatable {
    case splash(SplashFeature.State)
    case onboarding(OnboardingFeature.State)
    case tab(TabFeature.State)
}
```
- enum State + `ifCaseLet`으로 화면 전환
- SplashFeature delegate 패턴으로 인증 완료 이벤트 수신

### TabFeature
- Home / 댕플랜 / 동네산책 / My 4탭 구성
- `Scope`로 각 자식 Reducer 조합

### Example 타깃
- 8개 Feature 모듈에 Example 앱 타깃 추가
- 모듈별 독립 프리뷰 가능 (모듈 Example scheme 선택)

### 기타
- DesignSystem Assets.xcassets 기본 구조 생성

## 변경 레이어

- [x] App
- [x] Feature
- [ ] Domain
- [ ] Core
- [x] Shared

## 체크리스트

- [x] 빌드 확인 (tuist generate 성공)
- [x] 관련 테스트 추가/수정
- [x] 셀프 리뷰 완료

## Reference

- [TCA Navigation - ifCaseLet](https://pointfreeco.github.io/swift-composable-architecture/main/documentation/composablearchitecture/reducer/ifcaselet(_:action:then:fileid:line:)-2e2oc)