### PR TITLE
[Feat] 튜토리얼 UI 구현

### DIFF
--- a/Projects/Feature/AppCoordinator/Sources/AppFeature.swift
+++ b/Projects/Feature/AppCoordinator/Sources/AppFeature.swift
@@ -37,6 +37,10 @@ public struct AppFeature: Reducer {
                 }
                 return .none
 
+            case .onboarding(.delegate(.onboardingCompleted)):
+                state = .tab(TabFeature.State())
+                return .none
+
             case .splash, .onboarding, .tab:
                 return .none
             }

--- a/Projects/Feature/Onboarding/Sources/OnboardingFeature.swift
+++ b/Projects/Feature/Onboarding/Sources/OnboardingFeature.swift
@@ -1,26 +1,46 @@
 import Foundation
 import ComposableArchitecture
 
+// MARK: - OnboardingFeature
+
+/// 온보딩 플로우 coordinator
+/// - enum State로 순차 플로우 관리 (한 번에 하나의 child만 활성)
+/// - 튜토리얼 완료 시 delegate를 통해 AppFeature에 알림
 @Reducer
 public struct OnboardingFeature: Reducer {
 
     @ObservableState
-    public struct State: Equatable {
-        public init() {}
+    public enum State: Equatable {
+        case tutorial(TutorialFeature.State)
+
+        public init() {
+            self = .tutorial(TutorialFeature.State())
+        }
     }
 
     public init() {}
 
     public enum Action {
-        case onAppear
+        case tutorial(TutorialFeature.Action)
+        case delegate(Delegate)
+
+        public enum Delegate {
+            case onboardingCompleted
+        }
     }
 
     public var body: some ReducerOf<Self> {
         Reduce { state, action in
             switch action {
-            case .onAppear:
+            case .tutorial(.delegate(.tutorialCompleted)):
+                return .send(.delegate(.onboardingCompleted))
+
+            case .tutorial, .delegate:
                 return .none
             }
+        }
+        .ifCaseLet(\.tutorial, action: \.tutorial) {
+            TutorialFeature()
         }
     }
 }

--- a/Projects/Feature/Onboarding/Sources/OnboardingView.swift
+++ b/Projects/Feature/Onboarding/Sources/OnboardingView.swift
@@ -1,6 +1,10 @@
 import SwiftUI
 import ComposableArchitecture
 
+// MARK: - OnboardingView
+
+/// 온보딩 플로우 라우팅 View
+/// - OnboardingFeature의 enum State에 따라 child View를 표시
 public struct OnboardingView: View {
     @Bindable public var store: StoreOf<OnboardingFeature>
 
@@ -9,10 +13,12 @@ public struct OnboardingView: View {
     }
 
     public var body: some View {
-        Text("Onboarding")
-            .onAppear {
-                store.send(.onAppear)
+        switch store.state {
+        case .tutorial:
+            if let tutorialStore = store.scope(state: \.tutorial, action: \.tutorial) {
+                TutorialView(store: tutorialStore)
             }
+        }
     }
 }
 

--- a/Projects/Feature/Onboarding/Sources/Tutorial/TutorialFeature.swift
+++ b/Projects/Feature/Onboarding/Sources/Tutorial/TutorialFeature.swift
@@ -1,0 +1,80 @@
+import Foundation
+import ComposableArchitecture
+
+// MARK: - TutorialFeature
+
+/// 온보딩 튜토리얼 (3페이지 스와이프) child reducer
+/// - OnboardingFeature의 첫 번째 단계로 동작
+/// - 완료 시 delegate를 통해 OnboardingFeature에 알림
+@Reducer
+public struct TutorialFeature: Reducer {
+
+    @ObservableState
+    public struct State: Equatable {
+        public var currentPage: Int = 0
+
+        public var pages: [TutorialPage] = TutorialPage.allPages
+
+        public var isLastPage: Bool {
+            currentPage == pages.count - 1
+        }
+
+        public init() {}
+    }
+
+    public init() {}
+
+    public enum Action {
+        case pageChanged(Int)
+        case skipTapped
+        case startTapped
+        case delegate(Delegate)
+
+        public enum Delegate {
+            case tutorialCompleted
+        }
+    }
+
+    public var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case let .pageChanged(page):
+                state.currentPage = page
+                return .none
+
+            case .skipTapped, .startTapped:
+                // TODO: 튜토리얼 완료 여부를 UserDefaults/KeyChain에 저장하여 재노출 방지
+                return .send(.delegate(.tutorialCompleted))
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}
+
+// MARK: - TutorialPage
+
+public struct TutorialPage: Equatable, Identifiable, Sendable {
+    public let id: Int
+    public let title: String
+    public let subtitle: String
+
+    public static let allPages: [TutorialPage] = [
+        TutorialPage(
+            id: 0,
+            title: "우리 아이를 위한 생애 지출 계획,\n이제 똑독하게 준비해요",
+            subtitle: "앞으로 들어갈 비용을 미리 확인하고 관리하여\n우리 아이와의 미래를 든든하게 대비해요."
+        ),
+        TutorialPage(
+            id: 1,
+            title: "잊기 쉬운 데일리 케어,\n놓치지 않고 꼼꼼하게",
+            subtitle: "꼭 필요한 매일의 건강 기록과 일정을\n알림으로 놓치지 않게 챙겨드려요."
+        ),
+        TutorialPage(
+            id: 2,
+            title: "우리 아이에게 꼭 필요한 정보,\n내 주변에서 빠르게",
+            subtitle: "내 주변 동물병원과 애견 동반 장소를 한눈에!\n동네 이웃 보호자와의 발자국 메모로\n생생한 동네 소식을 실시간으로 나눠요."
+        ),
+    ]
+}

--- a/Projects/Feature/Onboarding/Sources/Tutorial/TutorialView.swift
+++ b/Projects/Feature/Onboarding/Sources/Tutorial/TutorialView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+import ComposableArchitecture
+import SharedDesignSystem
+
+// MARK: - TutorialView
+
+/// 튜토리얼 3페이지 스와이프 UI
+/// - 1~2페이지: 인디케이터(중앙) + 건너뛰기(우측)
+/// - 3페이지: 시작 버튼 + 인디케이터(중앙)
+public struct TutorialView: View {
+    @Bindable public var store: StoreOf<TutorialFeature>
+
+    public init(store: StoreOf<TutorialFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        VStack(spacing: 0) {
+            TabView(selection: $store.currentPage.sending(\.pageChanged)) {
+                ForEach(store.pages) { page in
+                    TutorialPageView(page: page)
+                        .tag(page.id)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+
+            bottomSection
+                .padding(.horizontal, 20)
+                .padding(.bottom, 40)
+        }
+        .background(Color.gray50)
+    }
+
+    private var bottomSection: some View {
+        VStack(spacing: 20) {
+            startButton
+                .opacity(store.isLastPage ? 1 : 0)
+
+            ZStack {
+                pageIndicator
+
+                HStack {
+                    Spacer()
+                    skipButton
+                        .opacity(store.isLastPage ? 0 : 1)
+                }
+            }
+        }
+        .animation(.easeInOut(duration: 0.25), value: store.isLastPage)
+    }
+
+    private var pageIndicator: some View {
+        HStack(spacing: 8) {
+            ForEach(0..<store.pages.count, id: \.self) { index in
+                Circle()
+                    .fill(index == store.currentPage ? Color.primary500 : Color.gray200)
+                    .frame(width: 8, height: 8)
+                    .animation(.easeInOut(duration: 0.25), value: store.currentPage)
+            }
+        }
+    }
+
+    // TODO: 똑독 시작하기 탭 시 튜토리얼 완료 후 이동할 화면 연결
+    private var startButton: some View {
+        Button {
+            store.send(.startTapped)
+        } label: {
+            Text("똑독 시작하기")
+                .typography(.buttonL)
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 70)
+                .background(Color.primary500)
+                .clipShape(RoundedRectangle(cornerRadius: 14))
+        }
+    }
+
+    // TODO: 건너뛰기 탭 시 튜토리얼 완료 후 이동할 화면 연결
+    private var skipButton: some View {
+        HStack {
+            Spacer()
+            Button {
+                store.send(.skipTapped)
+            } label: {
+                Text("건너뛰기")
+                    .typography(.body10)
+                    .foregroundStyle(Color.gray400)
+            }
+        }
+    }
+}
+
+// MARK: - TutorialPageView
+
+/// 튜토리얼 개별 페이지 콘텐츠
+struct TutorialPageView: View {
+    let page: TutorialPage
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Spacer()
+
+            Text(page.title)
+                .typography(.title1)
+                .foregroundStyle(Color.gray900)
+                .multilineTextAlignment(.center)
+
+            Text(page.subtitle)
+                .typography(.body4)
+                .foregroundStyle(Color.gray600)
+                .multilineTextAlignment(.center)
+
+            Spacer()
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+    }
+}
+
+#Preview {
+    TutorialView(
+        store: .init(
+            initialState: TutorialFeature.State(),
+            reducer: { TutorialFeature() }
+        )
+    )
+}


### PR DESCRIPTION
## Related Issue

- 없음

## Background

온보딩 첫 단계로 3페이지 스와이프 튜토리얼 UI를 구현합니다.
OnboardingFeature를 enum State 기반 플로우 coordinator로 변환하여 향후 로그인, 프로필 설정 등 순차 플로우 확장이 가능하도록 했습니다.

## Contents

### TutorialFeature (child reducer)
- 3페이지 튜토리얼 데이터 모델 및 상태 관리
- 건너뛰기 / 똑독 시작하기 → delegate로 완료 이벤트 전달

### TutorialView
- `TabView(.page)` 기반 스와이프 UI
- 1~2페이지: 페이지 인디케이터(중앙) + 건너뛰기(우측)
- 3페이지: 똑독 시작하기 버튼 + 페이지 인디케이터(중앙)
- 페이지 전환 시 fade 애니메이션 (0.25s easeInOut)

### OnboardingFeature 구조 변환
- struct State → enum State 기반 플로우 coordinator
- `ifCaseLet`으로 TutorialFeature child reducer 조합

### AppFeature
- 온보딩 완료 delegate 수신 → Tab 화면 전환

## 변경 레이어

- [ ] App
- [x] Feature
- [ ] Domain
- [ ] Core
- [ ] Shared

## 체크리스트

- [x] 빌드 확인
- [ ] 관련 테스트 추가/수정
- [x] 셀프 리뷰 완료

## Reference

- 없음