### PR TITLE
[Feat/#21]: 아이디/닉네임 입력용 TtokdogTextField 컴포넌트 추가

### DIFF
--- a/Projects/Feature/Onboarding/Sources/Components/TtokdogTextField.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/TtokdogTextField.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+import SharedDesignSystem
+
+
+struct TtokdogTextField: View {
+    
+    @Binding var text: String
+    
+    let title: String
+    let description: String
+    let placeholder: String
+    
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            titleView
+
+            HStack(spacing: 14) {
+                textFieldView
+                duplicateCheckButton()
+            }
+            .padding(.vertical, 7)
+            .padding(.leading, 16)
+            .padding(.trailing, 8)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color.gray200, lineWidth: 1.2)
+            )
+            
+            // TODO: 에러 문구
+        }
+    }
+    
+    // MARK: - 타이틀
+    private var titleView: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            // 타이틀 문구
+            Text(title)
+                .foregroundStyle(Color.gray700)
+                .typography(.body9)
+            
+            // 설명 문구
+            Text(description)
+                .foregroundStyle(Color.gray500)
+                .typography(.body11)
+        }
+    }
+    
+    // MARK: - 텍스트 필드
+    private var textFieldView: some View {
+        HStack {
+            TextField(placeholder, text: $text)
+                .foregroundStyle(Color.gray900)
+                .typography(.body11)
+            
+            if !text.isEmpty {
+                clearButton
+            }
+            
+        }
+    }
+    
+    // MARK: - 지우기 버튼
+    private var clearButton: some View {
+        Button {
+            text = ""
+        } label: {
+            // TODO: 아이콘 디자인시스템 반영하기
+            Image(systemName: "xmark.circle.fill")
+                .foregroundStyle(.gray)
+        }
+    }
+    
+    // MARK: - 중복확인 버튼
+    private func duplicateCheckButton() -> some View {
+        Button {
+
+        } label: {
+            Text("중복확인")
+                .foregroundStyle(Color.gray400)
+                .typography(.label1)
+                .padding(.horizontal, 18)
+                .padding(.vertical, 9)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 50)
+                        .stroke(Color.gray300, lineWidth: 1.2)
+                )
+        }
+    }
+    
+}
+
+
+
+
+// MARK: - Preview
+
+#Preview {
+    TtokdogTextField(
+        text: .constant("dsdsdsdsds"),
+        title: "타이틀",
+        description: "설명",
+        placeholder: "플레이스홀더"
+    )
+}


### PR DESCRIPTION
<!--
제목 컨벤션
[<라벨>/#<이슈 번호>] <제목>

제목은 명사형으로 마무리해주세요!

예시 >>
[Feat/#3] 홈 화면 산책 기록 카드 구현
[Fix/#7] Splash 화면 무한 로딩 수정
[Chore/#12] CI 워크플로우 캐시 개선
-->

<!-- 리뷰어, 담당자, 라벨 설정했는지 확인해주세요 -->

## Related Issue

- #21 

## Background

회원가입 시 아이디/닉네임 입력에 사용할 공통 텍스트필드 컴포넌트를 구현했습니다.


## Contents

- 아이디/닉네임 입력용 `TtokdogTextField` 공통 컴포넌트 구현



## 변경 레이어

- [ ] App
- [x] Feature
- [ ] Domain
- [ ] Core
- [ ] Shared

## 체크리스트

- [ ] 빌드 확인
- [ ] 관련 테스트 추가/수정
- [x] 셀프 리뷰 완료

## Reference
- 똑독 Figma 참고