### PR TITLE
[Feat/#20] 아이디/비밀번호 찾기 UI 구현

### DIFF
--- a/Projects/Feature/Onboarding/Sources/Components/ErrorLabel.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/ErrorLabel.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+import SharedDesignSystem
+
+// MARK: - ErrorLabel
+
+struct ErrorLabel: View {
+    let message: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 4) {
+            Image(systemName: "info.circle")
+                .font(.system(size: 14))
+                .foregroundStyle(Color.error)
+
+            Text(message)
+                .typography(.error)
+                .foregroundStyle(Color.error)
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    ErrorLabel(message: "올바른 이메일 형식을 입력해주세요.")
+        .padding(.horizontal, 20)
+}

--- a/Projects/Feature/Onboarding/Sources/Components/InputField.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/InputField.swift
@@ -1,0 +1,105 @@
+import SwiftUI
+import SharedDesignSystem
+
+// MARK: - InputField
+
+struct InputField: View {
+    let placeholder: String
+    @Binding var text: String
+    var isSecure: Bool = false
+    var isPasswordVisible: Bool = false
+    var onToggleVisibility: (() -> Void)? = nil
+    var keyboardType: UIKeyboardType = .default
+    var hasError: Bool = false
+
+    var body: some View {
+        HStack {
+            Group {
+                if isSecure && !isPasswordVisible {
+                    SecureField(placeholder, text: $text)
+                } else {
+                    TextField(placeholder, text: $text)
+                        .keyboardType(keyboardType)
+                }
+            }
+            .typography(.body11)
+            .autocorrectionDisabled()
+            .textInputAutocapitalization(.never)
+
+            if isSecure && !text.isEmpty {
+                Button {
+                    onToggleVisibility?()
+                } label: {
+                    (isPasswordVisible ? Image.eye : Image.eyeOff)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 24, height: 24)
+                        .foregroundStyle(Color.gray300)
+                }
+                .accessibilityLabel(isPasswordVisible ? "비밀번호 숨기기" : "비밀번호 보기")
+            }
+
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image.inputErase
+                        .resizable()
+                        .scaledToFit()
+                        .frame(width: 18, height: 18)
+                        .foregroundStyle(isSecure ? Color.gray400 : Color.gray300)
+                }
+                .accessibilityLabel("입력 내용 지우기")
+            }
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 52)
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(
+                    hasError ? Color.error : Color.gray200,
+                    lineWidth: 1
+                )
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview("기본") {
+    InputField(
+        placeholder: "example@example.com",
+        text: .constant("")
+    )
+    .padding(.horizontal, 20)
+}
+
+#Preview("입력 중") {
+    InputField(
+        placeholder: "example@example.com",
+        text: .constant("ttokdog@naver.com")
+    )
+    .padding(.horizontal, 20)
+}
+
+#Preview("에러") {
+    InputField(
+        placeholder: "example@example.com",
+        text: .constant("ttokdog"),
+        hasError: true
+    )
+    .padding(.horizontal, 20)
+}
+
+#Preview("비밀번호") {
+    InputField(
+        placeholder: "비밀번호를 입력해주세요",
+        text: .constant("password123"),
+        isSecure: true,
+        isPasswordVisible: false,
+        onToggleVisibility: {}
+    )
+    .padding(.horizontal, 20)
+}

--- a/Projects/Feature/Onboarding/Sources/Login/CredentialLogin/CredentialLoginFeature.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/CredentialLogin/CredentialLoginFeature.swift
@@ -4,7 +4,7 @@ import ComposableArchitecture
 // MARK: - CredentialLoginFeature
 
 @Reducer
-public struct CredentialLoginFeature: Reducer {
+public struct CredentialLoginFeature {
 
     // MARK: - State
 
@@ -14,6 +14,7 @@ public struct CredentialLoginFeature: Reducer {
         public var password: String = ""
         public var isPasswordVisible: Bool = false
         public var errorMessage: String?
+        @Presents var findAccount: FindAccountFeature.State?
 
         public var isLoginEnabled: Bool {
             !id.isEmpty && !password.isEmpty
@@ -32,6 +33,7 @@ public struct CredentialLoginFeature: Reducer {
         case togglePasswordVisibility
         case signUpTapped
         case findAccountTapped
+        case findAccount(PresentationAction<FindAccountFeature.Action>)
         case backButtonTapped
         case delegate(Delegate)
 
@@ -64,7 +66,15 @@ public struct CredentialLoginFeature: Reducer {
                 return .none
 
             case .findAccountTapped:
-                // TODO: 아이디/비밀번호 찾기 화면 연결
+                state.findAccount = FindAccountFeature.State()
+                return .none
+
+            case .findAccount(.presented(.backButtonTapped)),
+                 .findAccount(.presented(.delegate(.navigateToLogin))):
+                state.findAccount = nil
+                return .none
+
+            case .findAccount:
                 return .none
 
             case .backButtonTapped:
@@ -73,6 +83,9 @@ public struct CredentialLoginFeature: Reducer {
             case .delegate:
                 return .none
             }
+        }
+        .ifLet(\.$findAccount, action: \.findAccount) {
+            FindAccountFeature()
         }
     }
 }

--- a/Projects/Feature/Onboarding/Sources/Login/CredentialLogin/CredentialLoginView.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/CredentialLogin/CredentialLoginView.swift
@@ -28,18 +28,9 @@ public struct CredentialLoginView: View {
             .padding(.horizontal, 20)
 
             if let errorMessage = store.errorMessage {
-                HStack(alignment: .top, spacing: 4) {
-                    Image(systemName: "info.circle")
-                        .font(.system(size: 14))
-                        .foregroundStyle(Color.error)
-
-                    Text(errorMessage)
-                        .typography(.error)
-                        .foregroundStyle(Color.error)
-                        .multilineTextAlignment(.center)
-                }
-                .padding(.top, 20)
-                .padding(.bottom, 10)
+                ErrorLabel(message: errorMessage)
+                    .padding(.top, 20)
+                    .padding(.bottom, 10)
             } else {
                 Color.clear
                     .frame(height: 50)
@@ -54,6 +45,15 @@ public struct CredentialLoginView: View {
             Spacer()
         }
         .background(Color.gray50)
+        .navigationDestination(
+            item: $store.scope(
+                state: \.findAccount,
+                action: \.findAccount
+            )
+        ) { findAccountStore in
+            FindAccountView(store: findAccountStore)
+                .navigationBarBackButtonHidden()
+        }
         .onTapGesture {
             UIApplication.shared.sendAction(
                 #selector(UIResponder.resignFirstResponder),
@@ -65,80 +65,21 @@ public struct CredentialLoginView: View {
     // MARK: - Input Fields
 
     private var idField: some View {
-        HStack {
-            TextField("아이디를 입력해주세요", text: $store.id)
-                .typography(.body11)
-
-            if !store.id.isEmpty {
-                Button {
-                    store.id = ""
-                } label: {
-                    Image.inputErase
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 18, height: 18)
-                        .foregroundStyle(Color.gray300)
-                }
-            }
-        }
-        .padding(.horizontal, 14)
-        .frame(height: 52)
-        .background(Color.white)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(
-                    store.errorMessage != nil ? Color.error : Color.gray200,
-                    lineWidth: 1
-                )
+        InputField(
+            placeholder: "아이디를 입력해주세요",
+            text: $store.id,
+            hasError: store.errorMessage != nil
         )
     }
 
     private var passwordField: some View {
-        HStack {
-            Group {
-                if store.isPasswordVisible {
-                    TextField("비밀번호를 입력해주세요", text: $store.password)
-                } else {
-                    SecureField("비밀번호를 입력해주세요", text: $store.password)
-                }
-            }
-            .typography(.body11)
-
-            if !store.password.isEmpty {
-                Button {
-                    store.send(.togglePasswordVisibility)
-                } label: {
-                    (store.isPasswordVisible ? Image.eye : Image.eyeOff)
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 24, height: 24)
-                        .foregroundStyle(Color.gray300)
-                }
-            }
-
-            if !store.password.isEmpty {
-                Button {
-                    store.password = ""
-                } label: {
-                    Image.inputErase
-                        .resizable()
-                        .scaledToFit()
-                        .frame(width: 18, height: 18)
-                        .foregroundStyle(Color.gray400)
-                }
-            }
-        }
-        .padding(.horizontal, 14)
-        .frame(height: 52)
-        .background(Color.white)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(
-                    store.errorMessage != nil ? Color.error : Color.gray200,
-                    lineWidth: 1
-                )
+        InputField(
+            placeholder: "비밀번호를 입력해주세요",
+            text: $store.password,
+            isSecure: true,
+            isPasswordVisible: store.isPasswordVisible,
+            onToggleVisibility: { store.send(.togglePasswordVisibility) },
+            hasError: store.errorMessage != nil
         )
     }
 

--- a/Projects/Feature/Onboarding/Sources/Login/FindAccount/FindAccountFeature.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/FindAccount/FindAccountFeature.swift
@@ -1,0 +1,168 @@
+import Foundation
+import ComposableArchitecture
+
+// MARK: - FindAccountFeature
+
+@Reducer
+public struct FindAccountFeature {
+
+    // MARK: - Tab
+
+    public enum Tab: Int, CaseIterable, Equatable {
+        case findId
+        case findPassword
+
+        var title: String {
+            switch self {
+            case .findId: "아이디 찾기"
+            case .findPassword: "비밀번호 찾기"
+            }
+        }
+    }
+
+    // MARK: - FindIdState
+
+    public struct FindIdState: Equatable {
+        public var email: String = ""
+        public var emailError: String?
+        public var notFoundError: String?
+        // TODO: 인증번호 입력 상태 추가 (verificationCode, isVerificationSent, timer 등)
+        // TODO: 아이디 찾기 결과 상태 추가 (foundId 등)
+
+        public var isSendVerificationEnabled: Bool {
+            !email.isEmpty
+        }
+
+        public init() {}
+    }
+
+    // MARK: - FindPasswordState
+
+    public struct FindPasswordState: Equatable {
+        public var loginId: String = ""
+        public var email: String = ""
+        public var loginIdError: String?
+        public var emailError: String?
+        public var accountNotFoundError: String?
+
+        public var isTempPasswordEnabled: Bool {
+            !loginId.isEmpty && !email.isEmpty
+        }
+
+        public init() {}
+    }
+
+    // MARK: - State
+
+    @ObservableState
+    public struct State: Equatable {
+        public var selectedTab: Tab = .findId
+        public var findId: FindIdState = .init()
+        public var findPassword: FindPasswordState = .init()
+        public var showTempPasswordAlert: Bool = false
+        // TODO: 로딩 상태 추가 (isLoading)
+
+        public init() {}
+    }
+
+    public init() {}
+
+    // MARK: - Action
+
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        case tabSelected(Tab)
+        case sendVerificationTapped
+        // TODO: 인증번호 입력/확인 액션 추가 (verifyCodeTapped, resendVerificationTapped)
+        // TODO: 아이디 찾기 API 응답 액션 추가
+        case tempPasswordTapped
+        // TODO: 임시 비밀번호 발급 API 응답 액션 추가
+        case tempPasswordAlertConfirmed
+        case backButtonTapped
+        case delegate(Delegate)
+
+        public enum Delegate {
+            case navigateToLogin
+        }
+    }
+
+    // MARK: - Reducer
+
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+            case .binding(\.findId.email):
+                state.findId.emailError = nil
+                state.findId.notFoundError = nil
+                return .none
+
+            case .binding(\.findPassword.loginId):
+                state.findPassword.loginIdError = nil
+                state.findPassword.accountNotFoundError = nil
+                return .none
+
+            case .binding(\.findPassword.email):
+                state.findPassword.emailError = nil
+                state.findPassword.accountNotFoundError = nil
+                return .none
+
+            case .binding:
+                return .none
+
+            case .tabSelected(let tab):
+                state.selectedTab = tab
+                state.findId.emailError = nil
+                state.findId.notFoundError = nil
+                state.findPassword.loginIdError = nil
+                state.findPassword.emailError = nil
+                state.findPassword.accountNotFoundError = nil
+                return .none
+
+            case .sendVerificationTapped:
+                if !Self.isValidEmail(state.findId.email) {
+                    state.findId.emailError = "올바른 이메일 형식을 입력해주세요."
+                }
+                guard state.findId.emailError == nil else {
+                    return .none
+                }
+                // TODO: 인증번호 전송 API 연동
+                // TODO: API 성공 → 인증번호 입력 UI 표시, 타이머 시작
+                // TODO: API 실패 → notFoundError 설정 (가입 정보 없음)
+                return .none
+
+            case .tempPasswordTapped:
+                if state.findPassword.loginId.count < 6 || state.findPassword.loginId.count > 15 {
+                    state.findPassword.loginIdError = "아이디는 6~15자 이내로 입력해주세요."
+                }
+                if !Self.isValidEmail(state.findPassword.email) {
+                    state.findPassword.emailError = "올바른 이메일 형식을 입력해주세요."
+                }
+                guard state.findPassword.loginIdError == nil && state.findPassword.emailError == nil else {
+                    return .none
+                }
+                // TODO: 임시 비밀번호 발급 API 연동
+                // TODO: API 성공 → showTempPasswordAlert = true (현재 스텁)
+                // TODO: API 실패 → accountNotFoundError 설정 (가입된 정보 없음)
+                state.showTempPasswordAlert = true
+                return .none
+
+            case .tempPasswordAlertConfirmed:
+                state.showTempPasswordAlert = false
+                return .send(.delegate(.navigateToLogin))
+
+            case .backButtonTapped:
+                return .none
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+
+    private static func isValidEmail(_ email: String) -> Bool {
+        let pattern = "[A-Z0-9a-z._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}"
+        return NSPredicate(format: "SELF MATCHES %@", pattern).evaluate(with: email)
+    }
+}

--- a/Projects/Feature/Onboarding/Sources/Login/FindAccount/FindAccountView.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/FindAccount/FindAccountView.swift
@@ -1,0 +1,294 @@
+import SwiftUI
+import ComposableArchitecture
+import SharedDesignSystem
+
+// MARK: - FindAccountView
+
+public struct FindAccountView: View {
+    @Bindable public var store: StoreOf<FindAccountFeature>
+
+    public init(store: StoreOf<FindAccountFeature>) {
+        self.store = store
+    }
+
+    // MARK: - Body
+
+    public var body: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                CustomNavigationBar(
+                    title: "아이디/비밀번호 찾기",
+                    onBack: { store.send(.backButtonTapped) }
+                )
+
+                tabPicker
+
+                switch store.selectedTab {
+                case .findId:
+                    findIdContent
+                case .findPassword:
+                    findPasswordContent
+                }
+
+                Spacer()
+            }
+            .background(Color.gray50)
+            .onTapGesture {
+                UIApplication.shared.sendAction(
+                    #selector(UIResponder.resignFirstResponder),
+                    to: nil, from: nil, for: nil
+                )
+            }
+
+            if store.showTempPasswordAlert {
+                tempPasswordAlertOverlay
+            }
+        }
+    }
+
+    // MARK: - Tab Picker
+
+    private var tabPicker: some View {
+        HStack(spacing: 0) {
+            ForEach(FindAccountFeature.Tab.allCases, id: \.self) { tab in
+                Button {
+                    UIApplication.shared.sendAction(
+                        #selector(UIResponder.resignFirstResponder),
+                        to: nil, from: nil, for: nil
+                    )
+                    store.send(.tabSelected(tab))
+                } label: {
+                    VStack(spacing: 8) {
+                        Text(tab.title)
+                            .typography(store.selectedTab == tab ? .body9 : .body11)
+                            .foregroundStyle(
+                                store.selectedTab == tab ? Color.primary500 : Color.gray400
+                            )
+
+                        Rectangle()
+                            .fill(store.selectedTab == tab ? Color.primary500 : Color.gray200)
+                            .frame(height: store.selectedTab == tab ? 2 : 1)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+            }
+        }
+    }
+
+    // MARK: - 아이디 찾기
+
+    private var findIdContent: some View {
+        VStack {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("이메일")
+                    .typography(.body11)
+                    .foregroundStyle(Color.gray500)
+
+                InputField(
+                    placeholder: "example@example.com",
+                    text: $store.findId.email,
+                    keyboardType: .emailAddress,
+                    hasError: store.findId.emailError != nil || store.findId.notFoundError != nil
+                )
+
+                if let error = store.findId.emailError {
+                    ErrorLabel(message: error)
+                } else if let error = store.findId.notFoundError {
+                    ErrorLabel(message: error)
+                }
+            }
+
+            Button {
+                store.send(.sendVerificationTapped)
+            } label: {
+                Text("인증번호 전송")
+                    .typography(.buttonL)
+                    .foregroundStyle(store.findId.isSendVerificationEnabled ? .white : Color.gray400)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 60)
+                    .background(store.findId.isSendVerificationEnabled ? Color.primary500 : Color.gray300)
+                    .clipShape(RoundedRectangle(cornerRadius: 15))
+            }
+            .disabled(!store.findId.isSendVerificationEnabled)
+            .padding(.top, 46)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 24)
+    }
+
+    // MARK: - 비밀번호 찾기
+
+    private var findPasswordContent: some View {
+        VStack {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("아이디")
+                    .typography(.body11)
+                    .foregroundStyle(Color.gray500)
+
+                InputField(
+                    placeholder: "아이디를 입력해주세요",
+                    text: $store.findPassword.loginId,
+                    hasError: store.findPassword.loginIdError != nil || store.findPassword.accountNotFoundError != nil
+                )
+
+                if let error = store.findPassword.loginIdError {
+                    ErrorLabel(message: error)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 8) {
+                Text("이메일")
+                    .typography(.body11)
+                    .foregroundStyle(Color.gray500)
+
+                InputField(
+                    placeholder: "example@example.com",
+                    text: $store.findPassword.email,
+                    keyboardType: .emailAddress,
+                    hasError: store.findPassword.emailError != nil || store.findPassword.accountNotFoundError != nil
+                )
+
+                if let error = store.findPassword.emailError {
+                    ErrorLabel(message: error)
+                }
+            }
+            .padding(.top, 20)
+
+            Button {
+                store.send(.tempPasswordTapped)
+            } label: {
+                Text("임시 비밀번호 발급")
+                    .typography(.buttonL)
+                    .foregroundStyle(store.findPassword.isTempPasswordEnabled ? .white : Color.gray400)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 60)
+                    .background(store.findPassword.isTempPasswordEnabled ? Color.primary500 : Color.gray300)
+                    .clipShape(RoundedRectangle(cornerRadius: 15))
+            }
+            .disabled(!store.findPassword.isTempPasswordEnabled)
+            .padding(.top, 46)
+
+            if let error = store.findPassword.accountNotFoundError {
+                ErrorLabel(message: error)
+                    .frame(maxWidth: .infinity)
+                    .padding(.top, 10)
+            }
+        }
+        .padding(.top, 24)
+        .padding(.horizontal, 20)
+    }
+
+    // MARK: - 임시 비밀번호 발급 완료 Alert
+
+    private var tempPasswordAlertOverlay: some View {
+        CustomAlert(
+            title: "이메일로 임시 비밀번호를 보냈어요.",
+            description: "발급된 임시 비밀번호로 로그인 후,\n반드시 새 비밀번호로 변경해주세요.",
+            primaryButtonTitle: "로그인 하러가기",
+            primaryAction: { store.send(.tempPasswordAlertConfirmed) }
+        )
+    }
+
+}
+
+// MARK: - Preview
+
+#Preview("아이디 찾기") {
+    FindAccountView(
+        store: .init(
+            initialState: FindAccountFeature.State(),
+            reducer: { FindAccountFeature() }
+        )
+    )
+}
+
+#Preview("아이디 찾기 - 이메일 형식 에러") {
+    FindAccountView(
+        store: .init(
+            initialState: {
+                var state = FindAccountFeature.State()
+                state.findId.email = "ttokdog"
+                state.findId.emailError = "올바른 이메일 형식을 입력해주세요."
+                return state
+            }(),
+            reducer: { FindAccountFeature() }
+        )
+    )
+}
+
+#Preview("아이디 찾기 - 가입 정보 없음") {
+    FindAccountView(
+        store: .init(
+            initialState: {
+                var state = FindAccountFeature.State()
+                state.findId.email = "ttokdog@naver.com"
+                state.findId.notFoundError = "가입 정보가 없어요."
+                return state
+            }(),
+            reducer: { FindAccountFeature() }
+        )
+    )
+}
+
+#Preview("비밀번호 찾기 - 빈 상태") {
+    FindAccountView(
+        store: .init(
+            initialState: {
+                var state = FindAccountFeature.State()
+                state.selectedTab = .findPassword
+                return state
+            }(),
+            reducer: { FindAccountFeature() }
+        )
+    )
+}
+
+#Preview("비밀번호 찾기 - 유효성 에러") {
+    FindAccountView(
+        store: .init(
+            initialState: {
+                var state = FindAccountFeature.State()
+                state.selectedTab = .findPassword
+                state.findPassword.loginId = "t"
+                state.findPassword.loginIdError = "아이디는 6~15자 이내로 입력해주세요."
+                state.findPassword.email = "ttokdog"
+                state.findPassword.emailError = "올바른 이메일 형식을 입력해주세요."
+                return state
+            }(),
+            reducer: { FindAccountFeature() }
+        )
+    )
+}
+
+#Preview("비밀번호 찾기 - 가입 정보 없음") {
+    FindAccountView(
+        store: .init(
+            initialState: {
+                var state = FindAccountFeature.State()
+                state.selectedTab = .findPassword
+                state.findPassword.loginId = "t"
+                state.findPassword.email = "ttokdog@naver.com"
+                state.findPassword.accountNotFoundError = "가입된 정보가 없어요."
+                return state
+            }(),
+            reducer: { FindAccountFeature() }
+        )
+    )
+}
+
+#Preview("비밀번호 찾기 - 임시 비밀번호 발급 완료") {
+    FindAccountView(
+        store: .init(
+            initialState: {
+                var state = FindAccountFeature.State()
+                state.selectedTab = .findPassword
+                state.findPassword.loginId = "ttokdog"
+                state.findPassword.email = "ttokdog@naver.com"
+                state.showTempPasswordAlert = true
+                return state
+            }(),
+            reducer: { FindAccountFeature() }
+        )
+    )
+}

--- a/Projects/Shared/DesignSystem/Sources/Components/CustomAlert.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/CustomAlert.swift
@@ -1,0 +1,158 @@
+import SwiftUI
+
+// MARK: - CustomAlert
+
+public struct CustomAlert<Content: View>: View {
+    private let title: String
+    private let description: String?
+    private let content: Content
+    private let primaryButtonTitle: String
+    private let primaryAction: () -> Void
+    private let secondaryButtonTitle: String?
+    private let secondaryAction: (() -> Void)?
+
+    public init(
+        title: String,
+        description: String? = nil,
+        primaryButtonTitle: String,
+        primaryAction: @escaping () -> Void,
+        secondaryButtonTitle: String? = nil,
+        secondaryAction: (() -> Void)? = nil
+    ) where Content == EmptyView {
+        self.title = title
+        self.description = description
+        self.content = EmptyView()
+        self.primaryButtonTitle = primaryButtonTitle
+        self.primaryAction = primaryAction
+        self.secondaryButtonTitle = secondaryButtonTitle
+        self.secondaryAction = secondaryAction
+    }
+
+    public init(
+        title: String,
+        description: String? = nil,
+        primaryButtonTitle: String,
+        primaryAction: @escaping () -> Void,
+        secondaryButtonTitle: String? = nil,
+        secondaryAction: (() -> Void)? = nil,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.title = title
+        self.description = description
+        self.content = content()
+        self.primaryButtonTitle = primaryButtonTitle
+        self.primaryAction = primaryAction
+        self.secondaryButtonTitle = secondaryButtonTitle
+        self.secondaryAction = secondaryAction
+    }
+
+    public var body: some View {
+        ZStack {
+            Color.black.opacity(0.5)
+                .ignoresSafeArea()
+
+            VStack(spacing: 8) {
+                Text(title)
+                    .typography(.title3)
+                    .foregroundStyle(Color.gray900)
+                    .multilineTextAlignment(.center)
+
+                if let description {
+                    Text(description)
+                        .typography(.body8)
+                        .foregroundStyle(Color.gray500)
+                        .multilineTextAlignment(.center)
+                }
+
+                content
+
+                buttonArea
+                    .padding(.top, 8)
+            }
+            .padding(24)
+            .background(Color.white)
+            .clipShape(RoundedRectangle(cornerRadius: 15))
+            .padding(.horizontal, 20)
+        }
+    }
+
+    @ViewBuilder
+    private var buttonArea: some View {
+        if let secondaryButtonTitle, let secondaryAction {
+            HStack(spacing: 8) {
+                Button(action: secondaryAction) {
+                    Text(secondaryButtonTitle)
+                        .typography(.buttonL)
+                        .foregroundStyle(Color.gray600)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 54)
+                        .background(Color.gray100)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+
+                Button(action: primaryAction) {
+                    Text(primaryButtonTitle)
+                        .typography(.buttonL)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 54)
+                        .background(Color.primary500)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+            }
+        } else {
+            Button(action: primaryAction) {
+                Text(primaryButtonTitle)
+                    .typography(.buttonL)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 54)
+                    .background(Color.primary500)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("단일 버튼") {
+    CustomAlert(
+        title: "이메일로 임시 비밀번호를 보냈어요.",
+        description: "발급된 임시 비밀번호로 로그인 후,\n반드시 새 비밀번호로 변경해주세요.",
+        primaryButtonTitle: "로그인 하러가기",
+        primaryAction: {}
+    )
+}
+
+#Preview("2버튼") {
+    CustomAlert(
+        title: "우리 아이 수정을 그만할까요?",
+        description: "이전 화면으로 돌아가면\n수정된 내용은 저장되지 않아요.",
+        primaryButtonTitle: "이어서 할래요",
+        primaryAction: {},
+        secondaryButtonTitle: "나갈래요",
+        secondaryAction: {}
+    )
+}
+
+#Preview("타이틀만") {
+    CustomAlert(
+        title: "인증번호 재발송횟수(5회)를 초과했어요.\n24시간 뒤에 다시 시도하세요.",
+        primaryButtonTitle: "넘어가기",
+        primaryAction: {}
+    )
+}
+
+#Preview("커스텀 콘텐츠") {
+    CustomAlert(
+        title: "이메일로 가입하신 아이디를 보냈어요.",
+        description: "개인정보 보호를 위해 화면에는 일부만 표시해요.\n메일함에서 전체 아이디를 확인해주세요.",
+        primaryButtonTitle: "로그인 하러가기",
+        primaryAction: {}
+    ) {
+        Text("( 아이디 : tto*** )")
+            .typography(.body6)
+            .foregroundStyle(Color.primary500)
+    }
+}


### PR DESCRIPTION
## Related Issue

- #20

## Background

아이디/비밀번호 찾기 화면 UI를 구현했습니다. 탭 기반으로 아이디 찾기/비밀번호 찾기 플로우를 분리하고, 공통으로 사용되는 UI 요소를 재사용 컴포넌트로 추출했습니다.

## Contents

FindAccountFeature에서 탭별 State를 분리하여 관리합니다:

```swift
public struct FindIdState: Equatable {
    public var email: String = ""
    public var emailError: String?
    public var notFoundError: String?
}

public struct FindPasswordState: Equatable {
    public var loginId: String = ""
    public var email: String = ""
    public var loginIdError: String?
    public var emailError: String?
    public var accountNotFoundError: String?
}
```

CustomAlert는 제네릭으로 커스텀 콘텐츠를 지원합니다:

```swift
public struct CustomAlert<Content: View>: View {
    public init(
        title: String,
        description: String? = nil,
        primaryButtonTitle: String,
        primaryAction: @escaping () -> Void,
        secondaryButtonTitle: String? = nil,
        secondaryAction: (() -> Void)? = nil,
        @ViewBuilder content: () -> Content
    )
}
```

InputField, ErrorLabel을 CredentialLoginView 인라인 코드에서 추출하여 FindAccountView에서도 재사용합니다.

## 변경 레이어

- [ ] App
- [x] Feature
- [ ] Domain
- [ ] Core
- [x] Shared

## 체크리스트

- [x] 빌드 확인
- [ ] 관련 테스트 추가/수정
- [x] 셀프 리뷰 완료

## Reference

closes #20