### PR TITLE
[Feature/#31] SignupPasswordInputField 컴포넌트 생성

### DIFF
--- a/Projects/Feature/Onboarding/Sources/Components/InputField.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/InputField.swift
@@ -30,7 +30,7 @@ struct InputField: View {
                 Button {
                     onToggleVisibility?()
                 } label: {
-                    (isPasswordVisible ? Image.eye : Image.eyeOff)
+                    (isPasswordVisible ? Image.eyeOn : Image.eyeOff)
                         .resizable()
                         .scaledToFit()
                         .frame(width: 24, height: 24)

--- a/Projects/Feature/Onboarding/Sources/Components/SignupPasswordInputField.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/SignupPasswordInputField.swift
@@ -1,0 +1,132 @@
+import SwiftUI
+import SharedDesignSystem
+
+struct SignupPasswordInputField: View {
+    @Binding var text: String
+    
+    let placeholder: String
+    let isVisible: Bool
+    let isError: Bool
+    let onToggleVisibility: () -> Void
+    let onClear: () -> Void
+    
+    var body: some View {
+        
+        HStack {
+            Group {
+                if isVisible {
+                    TextField(placeholder, text: $text)
+                } else {
+                    SecureField(placeholder, text: $text)
+                }
+            }
+            .foregroundStyle(text.isEmpty ? Color.gray400 : Color.gray900)
+            .typography(.body11)
+            
+            
+            if !text.isEmpty {
+                HStack(spacing: 14) {
+                    Button(action: onToggleVisibility) {
+                        isVisible ? Image.eyeOff : Image.eye
+                    }
+                    
+                    Button(action: onClear) {
+                        Image.inputErase
+                    }
+                }
+            }
+        }
+        .padding(.vertical, 16)
+        .padding(.leading, 16)
+        .padding(.trailing, 14)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(isError ? Color.error : Color.gray200, lineWidth: 1.2)
+        )
+        
+    }
+}
+// MARK: - Preview
+#Preview("비밀번호 - 비어있음") {
+    SignupPasswordInputField(
+        text: .constant(""),
+        placeholder: "생성할 비밀번호를 입력해주세요",
+        isVisible: false,
+        isError: false,
+        onToggleVisibility: { },
+        onClear: { }
+    )
+    .padding()
+}
+
+#Preview("비밀번호 - 입력중 숨김") {
+    SignupPasswordInputField(
+        text: .constant("dbwldhks"),
+        placeholder: "생성할 비밀번호를 입력해주세요",
+        isVisible: false,
+        isError: false,
+        onToggleVisibility: { },
+        onClear: { }
+    )
+    .padding()
+}
+
+#Preview("비밀번호 - 입력중 보임") {
+    SignupPasswordInputField(
+        text: .constant("dbwldhks"),
+        placeholder: "생성할 비밀번호를 입력해주세요",
+        isVisible: true,
+        isError: false,
+        onToggleVisibility: { },
+        onClear: { }
+    )
+    .padding()
+}
+
+#Preview("비밀번호 확인 - 숨김") {
+    SignupPasswordInputField(
+        text: .constant("dbwldhks"),
+        placeholder: "비밀번호를 한번 더 입력해주세요",
+        isVisible: false,
+        isError: false,
+        onToggleVisibility: { },
+        onClear: { }
+    )
+    .padding()
+}
+
+#Preview("비밀번호 확인 - 보임") {
+    SignupPasswordInputField(
+        text: .constant("dbwldhks"),
+        placeholder: "비밀번호를 한번 더 입력해주세요",
+        isVisible: true,
+        isError: false,
+        onToggleVisibility: { },
+        onClear: { }
+    )
+    .padding()
+}
+
+#Preview("비밀번호 - 에러") {
+    SignupPasswordInputField(
+        text: .constant("dbwldhks"),
+        placeholder: "생성할 비밀번호를 입력해주세요",
+        isVisible: false,
+        isError: true,
+        onToggleVisibility: { },
+        onClear: { }
+    )
+    .padding()
+}
+
+#Preview("비밀번호 확인 - 에러") {
+    SignupPasswordInputField(
+        text: .constant("dbwldhks"),
+        placeholder: "비밀번호를 한번 더 입력해주세요",
+        isVisible: false,
+        isError: true,
+        onToggleVisibility: { },
+        onClear: { }
+    )
+    .padding()
+}

--- a/Projects/Feature/Onboarding/Sources/Components/SignupPasswordInputField.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/SignupPasswordInputField.swift
@@ -27,7 +27,7 @@ struct SignupPasswordInputField: View {
             if !text.isEmpty {
                 HStack(spacing: 14) {
                     Button(action: onToggleVisibility) {
-                        isVisible ? Image.eyeOff : Image.eye
+                        isVisible ? Image.eyeOff : Image.eyeOn
                     }
                     
                     Button(action: onClear) {


### PR DESCRIPTION
<!--
제목 컨벤션
[<라벨>/#<이슈 번호>] <제목>

제목은 명사형으로 마무리해주세요!

예시 >>
[Feat/#3] 홈 화면 산책 기록 카드 구현
[Fix/#7] Splash 화면 무한 로딩 수정
[Chore/#12] CI 워크플로우 캐시 개선
-->

<!-- 리뷰어, 담당자, 라벨 설정했는지 확인해주세요 -->

## Related Issue

- #31

## Background

온보딩 회원가입 화면의 비밀번호 입력 필드를 재사용 가능한 컴포넌트로 분리합니다.


## 변경 레이어

- [ ] App
- [x] Feature
- [ ] Domain
- [ ] Core
- [ ] Shared

## 체크리스트

- [ ] 빌드 확인
- [ ] 관련 테스트 추가/수정
- [x] 셀프 리뷰 완료

## Reference
- 없습니다.