### PR TITLE
[Feat/#34] 회원가입 하단 버튼 컴포넌트 구현

### DIFF
--- a/Projects/Feature/Onboarding/Sources/Components/SignUpBottomView.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/SignUpBottomView.swift
@@ -1,0 +1,75 @@
+import SwiftUI
+import SharedDesignSystem
+
+// MARK: - SignUp Bottom View
+/**
+ 회원가입 화면 하단 고정 액션 영역 컴포넌트
+ 
+ - 주요 기능:
+ - '이미 회원이신가요?' 로그인 전환 브릿지 제공
+ - '다음으로' 메인 액션 버튼 제공
+ **/
+struct SignUpBottomView: View {
+    
+    let isNextButtonEnabled: Bool // 다음으로 버튼 활성화 여부
+    let loginLinkAction: () -> Void // 로그인하러가기 버튼 탭 시 호출되는 클로저
+    let nextButtonAction: () -> Void // 다음으로 버튼 탭 시 호출되는 클로저
+    
+    var body: some View {
+        
+        VStack(spacing: 0) {
+            
+            // 이미 회원이신가요? 로그인하러가기
+            HStack(spacing: 4) {
+                Text("이미 회원이신가요?")
+                    .typographyText(.label3)
+                    .foregroundStyle(Color.gray400)
+                
+                Button {
+                    loginLinkAction()
+                } label: {
+                    Text("로그인하러가기")
+                        .typographyText(.label1)
+                        .foregroundStyle(Color.primary500)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 16)
+            
+            // 다음으로 버튼 (활성화 여부에 따라 색상 변경)
+            Button {
+                nextButtonAction()
+            } label: {
+                Text("다음으로")
+                    .typography(.buttonL)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 24)
+                    .background(isNextButtonEnabled ? Color.primary500 : Color.gray300)
+                    .foregroundStyle(isNextButtonEnabled ? Color.white : Color.gray400)
+                    .clipShape(RoundedRectangle(cornerRadius: 15))
+            }
+            .padding(.vertical, 18)
+            .padding(.horizontal, 20)
+            
+        }
+        .background(Color.white)
+        .shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: -4)
+        .mask(
+            Rectangle()
+                .padding(.top, -20) // 하단 그림자 잘라내기
+        )
+        
+    }
+}
+
+
+
+// MARK: - Preview
+#Preview("다음 버튼 - 활성화") {
+    SignUpBottomView(isNextButtonEnabled: true, loginLinkAction: { }, nextButtonAction: { })
+        
+}
+
+#Preview("다음 버튼 - 비활성화") {
+    SignUpBottomView(isNextButtonEnabled: false, loginLinkAction: { }, nextButtonAction: { })
+}


### PR DESCRIPTION
<!--
제목 컨벤션
[<라벨>/#<이슈 번호>] <제목>

제목은 명사형으로 마무리해주세요!

예시 >>
[Feat/#3] 홈 화면 산책 기록 카드 구현
[Fix/#7] Splash 화면 무한 로딩 수정
[Chore/#12] CI 워크플로우 캐시 개선
-->

<!-- 리뷰어, 담당자, 라벨 설정했는지 확인해주세요 -->

## Related Issue

- #34 

## Background

회원가입 화면 하단에 고정되는 버튼 영역 컴포넌트 구현

## Contents

- `SignUpBottomView` 컴포넌트 구현
  - 로그인하러가기 링크 버튼
  - 다음으로 버튼 (활성/비활성 상태 대응)
  - 상단 그림자 적용 (mask를 활용한 단방향 그림자)

```swift
.shadow(color: .black.opacity(0.1), radius: 10, x: 0, y: -4)
.mask(
    Rectangle()
        .padding(.top, -20) // mask 영역을 위로 축소해 하단 그림자 클리핑
)
```

## 변경 레이어

- [ ] App
- [x] Feature
- [ ] Domain
- [ ] Core
- [ ] Shared

## 체크리스트

- [ ] 빌드 확인
- [ ] 관련 테스트 추가/수정
- [x] 셀프 리뷰 완료

## Reference

- 없습니다.


## 고민한 내용
그림자를 mask  방식으로 했는데 더 나은 방법이 있다면 리뷰 부탁드립니다 
<img width="1332" height="472" alt="CleanShot 2026-04-28 at 00 32 55@2x" src="https://github.com/user-attachments/assets/b242d21d-13c8-4352-b20b-7d47b8a003d6" />