### PR TITLE
[Refactor/#36] TtokdogTextField titleView를 FieldHeader 컴포넌트로 분리

### DIFF
--- a/Projects/Feature/Onboarding/Sources/Components/FieldHeader.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/FieldHeader.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+import SharedDesignSystem
+
+struct FieldHeader: View {
+
+    let title: String
+    var description: String? = nil
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .foregroundStyle(Color.gray700)
+                .typography(.body9)
+            
+            if let description {
+                Text(description)
+                    .foregroundStyle(Color.gray500)
+                    .typography(.body11)
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+#Preview("설명 없음") {
+    FieldHeader(title: "이메일")
+        .padding(20)
+}
+
+#Preview("아이디") {
+    FieldHeader(title: "아이디",
+                description: "(6~15자 이내의 영문 소문자, 숫자 가능)")
+        .padding(20)
+}
+
+#Preview("비밀번호") {
+    FieldHeader(title: "비밀번호",
+                description: "(8~20자 이내의 영문/숫자/특수문자 혼합)")
+        .padding(20)
+}
+
+#Preview("닉네임") {
+    FieldHeader(title: "닉네임",
+                description: "(1~10자 이내의 한글/영문/숫자)")
+        .padding(20)
+}

--- a/Projects/Feature/Onboarding/Sources/Components/TtokdogTextField.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/TtokdogTextField.swift
@@ -6,14 +6,10 @@ struct TtokdogTextField: View {
     
     @Binding var text: String
     
-    let title: String
-    let description: String
     let placeholder: String
     
     public var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            titleView
-
+        VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 14) {
                 textFieldView
                 duplicateCheckButton()
@@ -25,25 +21,11 @@ struct TtokdogTextField: View {
                 RoundedRectangle(cornerRadius: 10)
                     .stroke(Color.gray200, lineWidth: 1.2)
             )
-            
             // TODO: 에러 문구
+            
         }
     }
     
-    // MARK: - 타이틀
-    private var titleView: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            // 타이틀 문구
-            Text(title)
-                .foregroundStyle(Color.gray700)
-                .typography(.body9)
-            
-            // 설명 문구
-            Text(description)
-                .foregroundStyle(Color.gray500)
-                .typography(.body11)
-        }
-    }
     
     // MARK: - 텍스트 필드
     private var textFieldView: some View {
@@ -93,12 +75,9 @@ struct TtokdogTextField: View {
 
 
 // MARK: - Preview
-
 #Preview {
     TtokdogTextField(
         text: .constant("dsdsdsdsds"),
-        title: "타이틀",
-        description: "설명",
         placeholder: "플레이스홀더"
     )
 }


### PR DESCRIPTION
<!--
제목 컨벤션
[<라벨>/#<이슈 번호>] <제목>

제목은 명사형으로 마무리해주세요!

예시 >>
[Feat/#3] 홈 화면 산책 기록 카드 구현
[Fix/#7] Splash 화면 무한 로딩 수정
[Chore/#12] CI 워크플로우 캐시 개선
-->

<!-- 리뷰어, 담당자, 라벨 설정했는지 확인해주세요 -->

## Related Issue

- #36

## Background

회원가입 화면에서 타이틀 + 설명 텍스트 조합이 반복적으로 사용되고 있어 컴포넌트 분리 필요


## Contents

- `FieldHeader` 컴포넌트 구현
  - `title`: 필수
  - `description`: 옵셔널 (없는 경우 숨김)
- `TtokdogTextField` 내 `titleView` → `FieldHeader` 로 분리
- `description` 타입 `String` → `String?` 변경


## 변경 레이어

- [ ] App
- [x] Feature
- [ ] Domain
- [ ] Core
- [ ] Shared

## 체크리스트

- [ ] 빌드 확인
- [ ] 관련 테스트 추가/수정
- [x] 셀프 리뷰 완료

## Reference
- 없습니다