### PR TITLE
[Feat/#42] 아이디 찾기 인증번호 입력 화면 및 온보딩 플로우 일관성 개선

### DIFF
--- a/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
+++ b/Projects/Feature/Onboarding/Example/Sources/OnboardingExampleApp.swift
@@ -6,22 +6,41 @@ import FeatureOnboarding
 struct OnboardingExampleApp: App {
     var body: some Scene {
         WindowGroup {
-//            OnboardingView(
-//                store: .init(
-//                    initialState: OnboardingFeature.State(),
-//                    reducer: { OnboardingFeature() }
-//                )
-//            )
-            
-            // MARK: - 디바이스 테스트용 (회원가입 화면)
-            // TODO: 실제 배포 시 OnboardingView로 교체 필요
-            TermsAgreementView(
+            // MARK: - 전체 온보딩 플로우 테스트 (튜토리얼부터 시작)
+            // 흐름:
+            //   1. 튜토리얼 (3페이지 스와이프) — Skip 또는 마지막 페이지 "시작하기"
+            //   2. 로그인 화면 (LoginView) — 소셜 로그인 / "다른계정으로 로그인"
+            //   3. 자격 로그인 화면 (CredentialLoginView) — 아이디/비번 입력 / "아이디·비밀번호 찾기"
+            //   4. 아이디 찾기 (FindAccountView) — 이메일 입력 → "인증번호 전송"
+            //   5. 인증번호 입력 (VerificationCodeView) — 6자리 입력 / 재전송 / 한도 alert / 인증 성공
+            //   6. 인증 성공 alert "로그인 하러가기" → CredentialLogin으로 자동 복귀
+            //
+            // 참고:
+            // - OnboardingFeature.State()는 매번 .tutorial로 시작하므로 "앱 처음 실행" 상태를 그대로 재현.
+            //   (실제 앱은 AppFeature/Splash에서 처음 실행 여부를 분기하지만, 여기서는 매번 처음부터.)
+            // - 인증번호 stub: "123456" → successEmailSignup alert, 그 외 6자리 → mismatch.
+            // - 시뮬레이터에서 클립보드에 6자리 숫자 복사 후 Cmd+V → staggered 자동완성 효과 확인 가능.
+            OnboardingView(
                 store: .init(
-                    initialState: TermsAgreementFeature.State(),
-                    reducer: { TermsAgreementFeature() }
+                    initialState: OnboardingFeature.State(),
+                    reducer: { OnboardingFeature() }
                 )
             )
-            
+
+            // MARK: - 이전 단독 테스트 화면들 (필요 시 위 OnboardingView를 주석 처리하고 사용)
+//            TermsAgreementView(
+//                store: .init(
+//                    initialState: TermsAgreementFeature.State(),
+//                    reducer: { TermsAgreementFeature() }
+//                )
+//            )
+//
+//            VerificationCodeView(
+//                store: .init(
+//                    initialState: VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com"),
+//                    reducer: { VerificationCodeFeature() }
+//                )
+//            )
         }
     }
 }

--- a/Projects/Feature/Onboarding/Sources/Components/InputField.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/InputField.swift
@@ -11,20 +11,34 @@ struct InputField: View {
     var onToggleVisibility: (() -> Void)? = nil
     var keyboardType: UIKeyboardType = .default
     var hasError: Bool = false
+    /// placeholder 글씨 색상 — nil이면 SwiftUI 기본(시스템 placeholder color),
+    /// 값이 지정되면 해당 색상으로 직접 렌더링한다.
+    var placeholderColor: Color? = nil
+
+    /// SwiftUI TextField/SecureField의 기본 placeholder 사용 여부
+    private var usesNativePlaceholder: Bool { placeholderColor == nil }
 
     var body: some View {
         HStack {
-            Group {
-                if isSecure && !isPasswordVisible {
-                    SecureField(placeholder, text: $text)
-                } else {
-                    TextField(placeholder, text: $text)
-                        .keyboardType(keyboardType)
+            ZStack(alignment: .leading) {
+                if let placeholderColor, text.isEmpty {
+                    Text(placeholder)
+                        .typography(.body11)
+                        .foregroundStyle(placeholderColor)
                 }
+                Group {
+                    if isSecure && !isPasswordVisible {
+                        SecureField(usesNativePlaceholder ? placeholder : "", text: $text)
+                    } else {
+                        TextField(usesNativePlaceholder ? placeholder : "", text: $text)
+                            .keyboardType(keyboardType)
+                    }
+                }
+                .typography(.body11)
+                .foregroundStyle(Color.gray900)   // 입력 텍스트 색상 — placeholder는 위 Text가 별도 처리
+                .autocorrectionDisabled()
+                .textInputAutocapitalization(.never)
             }
-            .typography(.body11)
-            .autocorrectionDisabled()
-            .textInputAutocapitalization(.never)
 
             if isSecure && !text.isEmpty {
                 Button {

--- a/Projects/Feature/Onboarding/Sources/Components/SignUpBottomView.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/SignUpBottomView.swift
@@ -41,18 +41,13 @@ struct SignUpBottomView: View {
             }
             
             // 다음으로 버튼 (활성화 여부에 따라 색상 변경)
-            Button {
+            PrimaryButton(
+                title: "다음으로",
+                isEnabled: isNextButtonEnabled,
+                height: 70
+            ) {
                 nextButtonAction()
-            } label: {
-                Text("다음으로")
-                    .typography(.buttonL)
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 24)
-                    .background(isNextButtonEnabled ? Color.primary500 : Color.gray300)
-                    .foregroundStyle(isNextButtonEnabled ? Color.white : Color.gray400)
-                    .clipShape(RoundedRectangle(cornerRadius: 15))
             }
-            .disabled(!isNextButtonEnabled)
             .padding(.vertical, 18)
             .padding(.horizontal, 20)
             

--- a/Projects/Feature/Onboarding/Sources/Components/VerificationCodeInputField.swift
+++ b/Projects/Feature/Onboarding/Sources/Components/VerificationCodeInputField.swift
@@ -1,0 +1,174 @@
+import SwiftUI
+import SharedDesignSystem
+
+/// 6자리 숫자 인증번호 입력 컴포넌트.
+///
+/// 화면에는 6개의 분리된 박스가 보이지만, 실제 입력 영역은 위에 깔린 투명한 단일
+/// `TextField`. iOS 시스템 키패드와 SMS 자동완성(`textContentType(.oneTimeCode)`)을 그대로 활용한다.
+public struct VerificationCodeInputField: View {
+
+    @Binding private var text: String
+    private let isError: Bool
+
+    @FocusState private var isFocused: Bool
+    /// 박스에 실제로 노출되는 글자 수.
+    /// 일괄 채움(자동완성/붙여넣기) 시 `text.count` 보다 작을 수 있으며 한 글자씩 증가하여 따라잡는다.
+    @State private var displayedLength: Int = 0
+
+    /// 입력 자릿수 (현재 화면에서는 상수 6)
+    private let length: Int = 6
+
+    /// 한 글자 채움 사이 간격
+    private let staggerDelay: Duration = .milliseconds(60)
+
+    public init(text: Binding<String>, isError: Bool) {
+        self._text = text
+        self.isError = isError
+    }
+
+    public var body: some View {
+        ZStack {
+            // 박스 6개 — 표시 전용
+            HStack(spacing: 8) {
+                ForEach(0..<length, id: \.self) { index in
+                    box(at: index)
+                }
+            }
+
+            // 실제 입력 영역 — 투명 TextField
+            // 자동 포커스는 다른 온보딩 화면과의 일관성을 위해 두지 않음.
+            // 사용자가 박스를 탭하면 first responder가 되어 키보드가 올라온다.
+            TextField("", text: $text)
+                .keyboardType(.numberPad)
+                .textContentType(.oneTimeCode)
+                .tint(.clear)              // 캐럿 숨김
+                .foregroundStyle(.clear)   // 입력 텍스트 숨김 (박스가 그림)
+                .focused($isFocused)
+                .onChange(of: text) { oldValue, newValue in
+                    // SMS 자동완성이 6자리 초과/숫자 외 문자를 삽입할 수 있어 View 단 방어 정제.
+                    // Reducer 측 binding(\.code) 정제와 이중 가드.
+                    let filtered = String(newValue.filter(\.isNumber).prefix(length))
+                    if text != filtered {
+                        text = filtered
+                        return  // 정제 후 다시 onChange가 들어오니 이번 이벤트는 종료
+                    }
+
+                    // 노출 길이 갱신 — 한 번에 2글자 이상 늘면 자동완성/붙여넣기로 보고 한 글자씩 채움.
+                    let oldCount = oldValue.count
+                    let newCount = filtered.count
+                    if newCount > oldCount + 1 {
+                        animateStaggeredFill(from: oldCount, to: newCount)
+                    } else {
+                        displayedLength = newCount
+                    }
+                }
+        }
+        // 입력값 변화 시 박스 fill/border/lineWidth가 부드럽게 전환 (자동완성 일괄 채움 시에도 동일).
+        .animation(.easeInOut(duration: 0.15), value: text)
+        .animation(.easeInOut(duration: 0.15), value: isError)
+    }
+
+    @ViewBuilder
+    private func box(at index: Int) -> some View {
+        let isCurrent = index == displayedLength && isFocused && !isError
+        let character = character(at: index)
+        let filled = !character.isEmpty
+
+        Text(character)
+            .typography(.head2)
+            .foregroundStyle(textColor(filled: filled))
+            .frame(maxWidth: .infinity)
+            .frame(height: 60)
+            .background(
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(fillColor(filled: filled))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(
+                        borderColor(isCurrent: isCurrent, filled: filled),
+                        lineWidth: borderLineWidth(isCurrent: isCurrent)
+                    )
+            )
+    }
+
+    private func character(at index: Int) -> String {
+        // 자동완성 staggered 채움 중에는 displayedLength까지만 노출.
+        guard index < min(text.count, displayedLength) else { return "" }
+        return String(text[text.index(text.startIndex, offsetBy: index)])
+    }
+
+    /// 일괄 채움 시 `from` → `to` 까지 한 글자씩 단계적으로 노출.
+    @MainActor
+    private func animateStaggeredFill(from start: Int, to end: Int) {
+        displayedLength = start
+        Task { @MainActor in
+            for i in 1...(end - start) {
+                try? await Task.sleep(for: staggerDelay)
+                // 도중에 다른 이벤트로 길이가 다시 줄거나 텍스트가 비워졌으면 중단
+                guard text.count >= start + i else { return }
+                displayedLength = start + i
+            }
+        }
+    }
+
+    /// 박스 안 숫자 색상 — 입력된 칸은 메인 컬러, 에러 시 에러 색.
+    private func textColor(filled: Bool) -> Color {
+        if isError { return .error }
+        if filled { return .primary500 }
+        return .gray900
+    }
+
+    private func fillColor(filled: Bool) -> Color {
+        if isError { return Color.error.opacity(0.08) }
+        return filled ? Color.primary100 : Color.white
+    }
+
+    /// 박스 테두리 — 에러 또는 입력 완료 칸은 테두리 없음, 현재 입력 위치만 메인 컬러 강조.
+    private func borderColor(isCurrent: Bool, filled: Bool) -> Color {
+        if isError || filled { return .clear }
+        if isCurrent { return .primary500 }
+        return .gray200
+    }
+
+    /// 박스 테두리 두께 — 현재 입력해야 하는 칸만 2pt, 그 외는 1.2pt.
+    private func borderLineWidth(isCurrent: Bool) -> CGFloat {
+        isCurrent ? 2 : 1.2
+    }
+}
+
+// MARK: - Preview
+
+#Preview("빈 상태") {
+    StatefulPreview(initial: "") { binding in
+        VerificationCodeInputField(text: binding, isError: false)
+            .padding()
+    }
+}
+
+#Preview("2자 입력") {
+    StatefulPreview(initial: "22") { binding in
+        VerificationCodeInputField(text: binding, isError: false)
+            .padding()
+    }
+}
+
+#Preview("에러 상태") {
+    StatefulPreview(initial: "225485") { binding in
+        VerificationCodeInputField(text: binding, isError: true)
+            .padding()
+    }
+}
+
+/// Preview에서 @Binding을 다루기 위한 작은 헬퍼.
+private struct StatefulPreview<Content: View>: View {
+    @State private var value: String
+    let content: (Binding<String>) -> Content
+
+    init(initial: String, @ViewBuilder content: @escaping (Binding<String>) -> Content) {
+        self._value = State(initialValue: initial)
+        self.content = content
+    }
+
+    var body: some View { content($value) }
+}

--- a/Projects/Feature/Onboarding/Sources/GuardianStatus/GuardianStatusView.swift
+++ b/Projects/Feature/Onboarding/Sources/GuardianStatus/GuardianStatusView.swift
@@ -43,12 +43,12 @@ public struct GuardianStatusView: View {
                 Spacer()
                 
                 startButton
-                
+
             }
             .padding(.top, 64)
             .padding(.horizontal, 20)
         }
-        
+        .background(Color.gray50)   // 다크모드에서도 일관된 배경 유지
     }
     
     // MARK: - Status Option Button

--- a/Projects/Feature/Onboarding/Sources/Login/CredentialLogin/CredentialLoginFeature.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/CredentialLogin/CredentialLoginFeature.swift
@@ -15,6 +15,8 @@ public struct CredentialLoginFeature {
         public var isPasswordVisible: Bool = false
         public var errorMessage: String?
         @Presents var findAccount: FindAccountFeature.State?
+        /// 회원가입 진입 — SignupView 정보 입력부터 시작 (다음으로 → 약관동의 → 보호자 상태 선택까지 SignupFeature 내부 체인)
+        @Presents var signup: SignupFeature.State?
 
         public var isLoginEnabled: Bool {
             !id.isEmpty && !password.isEmpty
@@ -34,6 +36,8 @@ public struct CredentialLoginFeature {
         case signUpTapped
         case findAccountTapped
         case findAccount(PresentationAction<FindAccountFeature.Action>)
+        /// 회원가입 화면 위임 액션
+        case signup(PresentationAction<SignupFeature.Action>)
         case backButtonTapped
         case delegate(Delegate)
 
@@ -62,7 +66,21 @@ public struct CredentialLoginFeature {
                 return .none
 
             case .signUpTapped:
-                // TODO: 회원가입 화면 연결
+                // 회원가입 진입 — SignupView 정보 입력부터 시작
+                state.signup = SignupFeature.State()
+                return .none
+
+            case .signup(.presented(.delegate(.navigateToLogin))):
+                // SignupView "로그인 하러가기" 또는 약관동의 X → 회원가입 플로우 종료, 작성 데이터 폐기
+                state.signup = nil
+                return .none
+
+            case .signup(.presented(.delegate(.signupFlowCompleted))):
+                // TODO: 회원가입 전체 플로우 완료 → 메인 진입 등 후속 단계 연결
+                state.signup = nil
+                return .none
+
+            case .signup:
                 return .none
 
             case .findAccountTapped:
@@ -86,6 +104,9 @@ public struct CredentialLoginFeature {
         }
         .ifLet(\.$findAccount, action: \.findAccount) {
             FindAccountFeature()
+        }
+        .ifLet(\.$signup, action: \.signup) {
+            SignupFeature()
         }
     }
 }

--- a/Projects/Feature/Onboarding/Sources/Login/CredentialLogin/CredentialLoginView.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/CredentialLogin/CredentialLoginView.swift
@@ -54,12 +54,16 @@ public struct CredentialLoginView: View {
             FindAccountView(store: findAccountStore)
                 .navigationBarBackButtonHidden()
         }
-        .onTapGesture {
-            UIApplication.shared.sendAction(
-                #selector(UIResponder.resignFirstResponder),
-                to: nil, from: nil, for: nil
+        .navigationDestination(
+            item: $store.scope(
+                state: \.signup,
+                action: \.signup
             )
+        ) { signupStore in
+            SignupView(store: signupStore)
+                .navigationBarBackButtonHidden()
         }
+        .dismissKeyboardOnTap()
     }
 
     // MARK: - Input Fields
@@ -68,7 +72,8 @@ public struct CredentialLoginView: View {
         InputField(
             placeholder: "아이디를 입력해주세요",
             text: $store.id,
-            hasError: store.errorMessage != nil
+            hasError: store.errorMessage != nil,
+            placeholderColor: .gray400
         )
     }
 
@@ -79,25 +84,17 @@ public struct CredentialLoginView: View {
             isSecure: true,
             isPasswordVisible: store.isPasswordVisible,
             onToggleVisibility: { store.send(.togglePasswordVisibility) },
-            hasError: store.errorMessage != nil
+            hasError: store.errorMessage != nil,
+            placeholderColor: .gray400
         )
     }
 
     // MARK: - Login Button
 
     private var loginButton: some View {
-        Button {
+        PrimaryButton(title: "로그인", isEnabled: store.isLoginEnabled) {
             store.send(.loginTapped)
-        } label: {
-            Text("로그인")
-                .typography(.buttonL)
-                .foregroundStyle(store.isLoginEnabled ? .white : Color.gray400)
-                .frame(maxWidth: .infinity)
-                .frame(height: 54)
-                .background(store.isLoginEnabled ? Color.primary500 : Color.gray300)
-                .clipShape(RoundedRectangle(cornerRadius: 15))
         }
-        .disabled(!store.isLoginEnabled)
     }
 
     // MARK: - Bottom Links

--- a/Projects/Feature/Onboarding/Sources/Login/FindAccount/FindAccountFeature.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/FindAccount/FindAccountFeature.swift
@@ -26,8 +26,6 @@ public struct FindAccountFeature {
         public var email: String = ""
         public var emailError: String?
         public var notFoundError: String?
-        // TODO: 인증번호 입력 상태 추가 (verificationCode, isVerificationSent, timer 등)
-        // TODO: 아이디 찾기 결과 상태 추가 (foundId 등)
 
         public var isSendVerificationEnabled: Bool {
             !email.isEmpty
@@ -62,6 +60,9 @@ public struct FindAccountFeature {
         public var showTempPasswordAlert: Bool = false
         // TODO: 로딩 상태 추가 (isLoading)
 
+        /// 인증번호 입력 화면 (push) — 인증번호 전송 성공 시 활성화
+        @Presents public var verification: VerificationCodeFeature.State?
+
         public init() {}
     }
 
@@ -79,6 +80,8 @@ public struct FindAccountFeature {
         // TODO: 임시 비밀번호 발급 API 응답 액션 추가
         case tempPasswordAlertConfirmed
         case backButtonTapped
+        /// 인증번호 입력 화면 위임 액션
+        case verification(PresentationAction<VerificationCodeFeature.Action>)
         case delegate(Delegate)
 
         public enum Delegate {
@@ -127,9 +130,9 @@ public struct FindAccountFeature {
                 guard state.findId.emailError == nil else {
                     return .none
                 }
-                // TODO: 인증번호 전송 API 연동
-                // TODO: API 성공 → 인증번호 입력 UI 표시, 타이머 시작
-                // TODO: API 실패 → notFoundError 설정 (가입 정보 없음)
+                // TODO: 인증번호 전송 API 연동 — 성공 시점에 push로 변경.
+                //       현재는 stub: 검증 통과 즉시 인증번호 입력 화면으로 이동.
+                state.verification = .init(maskedEmail: Self.mask(state.findId.email))
                 return .none
 
             case .tempPasswordTapped:
@@ -155,14 +158,40 @@ public struct FindAccountFeature {
             case .backButtonTapped:
                 return .none
 
+            case .verification(.presented(.delegate(.popToFindAccount))):
+                state.verification = nil
+                return .none
+
+            case .verification(.presented(.delegate(.navigateToLogin))):
+                // 인증 성공 후 로그인 화면 이동 — FindAccount도 dismiss하고 부모(CredentialLogin)에 위임 전파.
+                state.verification = nil
+                return .send(.delegate(.navigateToLogin))
+
+            case .verification:
+                return .none
+
             case .delegate:
                 return .none
             }
+        }
+        .ifLet(\.$verification, action: \.verification) {
+            VerificationCodeFeature()
         }
     }
 
     private static func isValidEmail(_ email: String) -> Bool {
         let pattern = "[A-Z0-9a-z._%+\\-]+@[A-Za-z0-9.\\-]+\\.[A-Za-z]{2,}"
         return NSPredicate(format: "SELF MATCHES %@", pattern).evaluate(with: email)
+    }
+
+    /// 이메일 마스킹 — 로컬 파트 앞 3글자만 노출, 나머지는 `*` 4개로 고정. 도메인은 그대로.
+    /// 예: "ttokdog@gmail.com" → "tto****@gmail.com"
+    /// 로컬 파트가 3글자 이하면 그 자체 + `****` + `@도메인`.
+    private static func mask(_ email: String) -> String {
+        guard let atIndex = email.firstIndex(of: "@") else { return email }
+        let local = email[..<atIndex]
+        let domain = email[atIndex...]   // "@gmail.com" 포함
+        let visible = local.prefix(3)
+        return "\(visible)****\(domain)"
     }
 }

--- a/Projects/Feature/Onboarding/Sources/Login/FindAccount/FindAccountView.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/FindAccount/FindAccountView.swift
@@ -33,12 +33,13 @@ public struct FindAccountView: View {
                 Spacer()
             }
             .background(Color.gray50)
-            .onTapGesture {
-                UIApplication.shared.sendAction(
-                    #selector(UIResponder.resignFirstResponder),
-                    to: nil, from: nil, for: nil
-                )
+            .navigationDestination(
+                item: $store.scope(state: \.verification, action: \.verification)
+            ) { verificationStore in
+                VerificationCodeView(store: verificationStore)
+                    .navigationBarBackButtonHidden()
             }
+            .dismissKeyboardOnTap()
 
             if store.showTempPasswordAlert {
                 tempPasswordAlertOverlay
@@ -99,18 +100,12 @@ public struct FindAccountView: View {
                 }
             }
 
-            Button {
+            PrimaryButton(
+                title: "인증번호 전송",
+                isEnabled: store.findId.isSendVerificationEnabled
+            ) {
                 store.send(.sendVerificationTapped)
-            } label: {
-                Text("인증번호 전송")
-                    .typography(.buttonL)
-                    .foregroundStyle(store.findId.isSendVerificationEnabled ? .white : Color.gray400)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 60)
-                    .background(store.findId.isSendVerificationEnabled ? Color.primary500 : Color.gray300)
-                    .clipShape(RoundedRectangle(cornerRadius: 15))
             }
-            .disabled(!store.findId.isSendVerificationEnabled)
             .padding(.top, 46)
         }
         .padding(.horizontal, 20)
@@ -155,18 +150,12 @@ public struct FindAccountView: View {
             }
             .padding(.top, 20)
 
-            Button {
+            PrimaryButton(
+                title: "임시 비밀번호 발급",
+                isEnabled: store.findPassword.isTempPasswordEnabled
+            ) {
                 store.send(.tempPasswordTapped)
-            } label: {
-                Text("임시 비밀번호 발급")
-                    .typography(.buttonL)
-                    .foregroundStyle(store.findPassword.isTempPasswordEnabled ? .white : Color.gray400)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 60)
-                    .background(store.findPassword.isTempPasswordEnabled ? Color.primary500 : Color.gray300)
-                    .clipShape(RoundedRectangle(cornerRadius: 15))
             }
-            .disabled(!store.findPassword.isTempPasswordEnabled)
             .padding(.top, 46)
 
             if let error = store.findPassword.accountNotFoundError {

--- a/Projects/Feature/Onboarding/Sources/Login/FindAccount/VerificationCode/VerificationCodeClient.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/FindAccount/VerificationCode/VerificationCodeClient.swift
@@ -1,0 +1,69 @@
+import Foundation
+import ComposableArchitecture
+
+// MARK: - Response
+
+/// 인증번호 검증 요청 결과
+public enum VerifyResponse: Equatable, Sendable {
+    /// 인증번호 불일치
+    case mismatch
+    /// 인증 성공 — 마스킹된 가입 아이디 동봉 (이메일로 전송됨)
+    case successEmailSignup(maskedId: String)
+    /// 인증 성공 — 이미 소셜 가입된 계정
+    case successSocialSignup(provider: VerificationCodeFeature.SocialProvider)
+    /// 입력 시도 횟수(5회) 초과 (서버 권위)
+    case attemptExceeded
+    /// 일일 인증 요청 횟수(10회) 초과 (서버 권위)
+    case dailyExceeded
+}
+
+/// 인증번호 재전송 요청 결과
+public enum ResendResponse: Equatable, Sendable {
+    /// 재전송 성공
+    case sent
+    /// 재전송 횟수(5회) 초과
+    case resendExceeded
+    /// 일일 인증 요청 횟수(10회) 초과
+    case dailyExceeded
+}
+
+// MARK: - Client
+
+/// 인증번호 검증/재전송 의존성.
+///
+/// 백엔드 미연동 단계에서는 stub `liveValue`로 동작하며,
+/// 실 연동 시 `Domain/Service` 프로토콜로 추출한 뒤 `Domain/Data` 구현으로 교체한다.
+@DependencyClient
+public struct VerificationCodeClient: Sendable {
+    /// 인증번호 검증
+    public var verify: @Sendable (_ email: String, _ code: String) async throws -> VerifyResponse
+    /// 인증번호 재전송
+    public var resend: @Sendable (_ email: String) async throws -> ResendResponse
+}
+
+extension VerificationCodeClient: DependencyKey {
+    /// 1차 구현 단계 — 실제 백엔드 연동 전 stub.
+    /// `123456`은 성공(이메일 가입), 그 외 6자리는 mismatch로 응답.
+    public static let liveValue: VerificationCodeClient = .init(
+        verify: { _, code in
+            try? await Task.sleep(for: .seconds(1))
+            switch code {
+            case "123456": return .successEmailSignup(maskedId: "tto***")
+            default:       return .mismatch
+            }
+        },
+        resend: { _ in
+            try? await Task.sleep(for: .seconds(1))
+            return .sent
+        }
+    )
+
+    public static let testValue = VerificationCodeClient()
+}
+
+public extension DependencyValues {
+    var verificationCodeClient: VerificationCodeClient {
+        get { self[VerificationCodeClient.self] }
+        set { self[VerificationCodeClient.self] = newValue }
+    }
+}

--- a/Projects/Feature/Onboarding/Sources/Login/FindAccount/VerificationCode/VerificationCodeFeature.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/FindAccount/VerificationCode/VerificationCodeFeature.swift
@@ -1,0 +1,349 @@
+import Foundation
+import ComposableArchitecture
+
+// MARK: - VerificationCodeFeature
+
+@Reducer
+public struct VerificationCodeFeature {
+
+    // MARK: - 정책 상수
+
+    /// 화면 정책 단일 출처 (Single Source of Truth).
+    private enum Policy {
+        /// 인증 입력 제한 시간 (초)
+        static let totalSeconds: Int = 180
+        /// 재전송 버튼 활성화 임계 — 남은 시간 ≤ 120초일 때 활성화
+        static let resendUnlockThreshold: Int = 120
+        /// 인증 입력 시도 한도 — 초과 시 attemptExceeded alert
+        static let maxAttempts: Int = 5
+        /// 인증번호 재전송 한도 — 초과 시 resendExceeded alert
+        static let maxResends: Int = 5
+    }
+
+    // MARK: - 부가 타입
+
+    /// 소셜 로그인 제공자 (성공 alert 텍스트 분기에 사용)
+    public enum SocialProvider: String, Equatable, Sendable {
+        case kakao, google, apple
+
+        /// alert 본문에 노출되는 한글 표기
+        public var displayName: String {
+            switch self {
+            case .kakao:  "카카오"
+            case .google: "구글"
+            case .apple:  "애플"
+            }
+        }
+    }
+
+    /// 입력 필드 시각 상태
+    public enum InputState: Equatable {
+        /// 미입력 / 입력 중 (정상 톤)
+        case idle
+        /// 코드 오류 (빨간 박스 + 하단 메시지)
+        case error
+    }
+
+    /// 입력 필드 하단에 표시되는 인라인 메시지
+    public enum BottomMessage: Equatable {
+        /// "인증번호를 정확히 입력해주세요. (n회 남음)"
+        case codeMismatch(remaining: Int)
+        /// "인증번호가 재전송되었어요. 메일함을 확인해주세요"
+        case resent
+    }
+
+    /// alert 종류 — single source of truth로 reducer가 분기
+    public enum AlertKind: Equatable {
+        /// 3분 타이머 만료 → "확인" (모달만 닫기)
+        case timeExpired
+        /// 입력 5회 초과 → "확인" (모달만 닫기)
+        case attemptExceeded
+        /// 재전송 5회 초과 → "돌아가기" (pop)
+        case resendExceeded
+        /// 일일 인증 요청 10회 초과 → "돌아가기" (pop)
+        case dailyExceeded
+        /// 이메일 가입 계정 — 마스킹된 아이디 발송 안내
+        case successEmailSignup(maskedId: String)
+        /// 소셜 가입 계정 — 해당 소셜 로그인 안내
+        case successSocialSignup(provider: SocialProvider)
+    }
+
+    // MARK: - State
+
+    @ObservableState
+    public struct State: Equatable {
+        // MARK: - 입력
+        /// 마스킹된 이메일 (예: "tto****@gmail.com") — 부모 화면에서 주입
+        public var maskedEmail: String
+        /// 사용자가 입력한 인증번호 (0~6자리, 숫자만)
+        public var code: String = ""
+
+        // MARK: - 타이머
+        /// 남은 시간 (초). 초기 180.
+        public var remainingSeconds: Int = Policy.totalSeconds
+        /// 타이머 동작 여부
+        public var isTimerRunning: Bool = false
+
+        // MARK: - 카운트
+        /// 인증 확인 시도 횟수 (낙관적 카운트)
+        public var attemptCount: Int = 0
+        /// 인증번호 재전송 횟수
+        public var resendCount: Int = 0
+
+        // MARK: - 진행 상태 (연타 방지)
+        /// 인증 확인 요청 진행 중 — 응답 대기 동안 추가 탭 차단
+        public var isVerifying: Bool = false
+        /// 재전송 요청 진행 중 — 응답 대기 동안 추가 탭 차단
+        public var isResending: Bool = false
+
+        // MARK: - UI
+        /// 입력 박스 시각 상태
+        public var inputState: InputState = .idle
+        /// 입력 박스 하단 인라인 메시지 (없으면 nil)
+        public var bottomMessage: BottomMessage? = nil
+        /// 표시 중인 alert (없으면 nil)
+        public var alert: AlertKind? = nil
+
+        // MARK: - 파생값
+
+        /// 6자리 모두 채워졌는지
+        public var isCodeFilled: Bool { code.count == 6 }
+
+        /// 재전송 버튼 활성화 — 남은시간 2분 이하 + 재전송 횟수 5회 미만 + 진행 중 아님
+        public var isResendEnabled: Bool {
+            remainingSeconds <= Policy.resendUnlockThreshold
+                && resendCount < Policy.maxResends
+                && !isResending
+        }
+
+        /// 인증 확인 버튼 활성화 — 6자리 완성 + 에러 상태가 아님 + 진행 중 아님
+        public var isVerifyEnabled: Bool {
+            isCodeFilled && inputState != .error && !isVerifying
+        }
+
+        /// "MM:SS" 포맷 (예: "03:00", "00:42")
+        public var formattedTime: String {
+            String(format: "%02d:%02d", remainingSeconds / 60, remainingSeconds % 60)
+        }
+
+        public init(maskedEmail: String) {
+            self.maskedEmail = maskedEmail
+        }
+    }
+
+    // MARK: - Action
+
+    public enum Action: BindableAction {
+        case binding(BindingAction<State>)
+        /// 화면 onAppear — 타이머 시작
+        case onAppear
+        /// 1초 경과 (타이머 effect가 디스패치)
+        case timerTicked
+        /// "인증 확인" 버튼 탭
+        case verifyTapped
+        /// 인증 검증 응답
+        case verifyResponse(VerifyResponse)
+        /// "재전송" 버튼 탭
+        case resendTapped
+        /// 재전송 응답
+        case resendResponse(ResendResponse)
+        /// alert primary 버튼 탭
+        case alertConfirmed
+        /// 네비게이션 뒤로가기 버튼 탭
+        case backButtonTapped
+        /// 부모(FindAccount)에 위임할 이벤트
+        case delegate(Delegate)
+
+        @CasePathable
+        public enum Delegate: Equatable {
+            /// FindAccount 화면으로 pop 요청 (한도 초과 등)
+            case popToFindAccount
+            /// 로그인 화면으로 이동 (인증 성공 후 "로그인 하러가기" / "OO 로그인" 탭)
+            case navigateToLogin
+        }
+    }
+
+    // MARK: - Cancellation IDs
+
+    /// 사이드 이펙트 취소 식별자
+    private enum CancelID: Hashable {
+        case timer, verify, resend
+    }
+
+    // MARK: - Dependencies
+
+    @Dependency(\.continuousClock) var clock
+    @Dependency(\.verificationCodeClient) var client
+
+    public init() {}
+
+    // MARK: - Reducer
+
+    public var body: some ReducerOf<Self> {
+        BindingReducer()
+
+        Reduce { state, action in
+            switch action {
+
+            // MARK: Binding
+
+            case .binding(\.code):
+                // 숫자만 추리고 6자로 자르기
+                let digitsOnly = state.code.filter(\.isNumber)
+                let trimmed = String(digitsOnly.prefix(6))
+                if state.code != trimmed {
+                    state.code = trimmed
+                }
+                // 입력이 다시 시작되면 에러 톤/안내 메시지 해제
+                if state.inputState == .error {
+                    state.inputState = .idle
+                }
+                if case .codeMismatch = state.bottomMessage {
+                    state.bottomMessage = nil
+                }
+                return .none
+
+            case .binding:
+                return .none
+
+            // MARK: Timer
+
+            case .onAppear:
+                // 이미 동작 중이면 재시작하지 않음 (네비 재진입 방어)
+                guard !state.isTimerRunning else { return .none }
+                state.isTimerRunning = true
+                return .run { [clock] send in
+                    for await _ in clock.timer(interval: .seconds(1)) {
+                        await send(.timerTicked)
+                    }
+                }
+                .cancellable(id: CancelID.timer, cancelInFlight: true)
+
+            case .timerTicked:
+                state.remainingSeconds = max(0, state.remainingSeconds - 1)
+                if state.remainingSeconds == 0 {
+                    state.isTimerRunning = false
+                    state.alert = .timeExpired
+                    return .cancel(id: CancelID.timer)
+                }
+                return .none
+
+            // MARK: Verify
+
+            case .verifyTapped:
+                // 6자리 채워졌고 에러/진행 상태 아닐 때만 호출 (UI 가드와 이중 방어)
+                guard state.isVerifyEnabled else { return .none }
+                state.isVerifying = true
+                state.attemptCount += 1   // 낙관적 카운트 — UI의 (n회 남음) 즉시 갱신
+                let email = state.maskedEmail   // TODO: [백엔드 연동] 원본 이메일로 교체 (현재는 마스킹값 전달)
+                let code = state.code
+                return .run { [client] send in
+                    await send(.verifyResponse(try await client.verify(email, code)))
+                }
+                .cancellable(id: CancelID.verify, cancelInFlight: true)
+
+            case .verifyResponse(.mismatch):
+                state.isVerifying = false
+                state.inputState = .error
+                let remaining = max(0, Policy.maxAttempts - state.attemptCount)
+                state.bottomMessage = .codeMismatch(remaining: remaining)
+                if state.attemptCount >= Policy.maxAttempts {
+                    state.alert = .attemptExceeded
+                    return .cancel(id: CancelID.timer)
+                }
+                return .none
+
+            case .verifyResponse(.successEmailSignup(let maskedId)):
+                state.isVerifying = false
+                state.isTimerRunning = false
+                state.alert = .successEmailSignup(maskedId: maskedId)
+                return .cancel(id: CancelID.timer)
+
+            case .verifyResponse(.successSocialSignup(let provider)):
+                state.isVerifying = false
+                state.isTimerRunning = false
+                state.alert = .successSocialSignup(provider: provider)
+                return .cancel(id: CancelID.timer)
+
+            case .verifyResponse(.attemptExceeded):
+                state.isVerifying = false
+                state.alert = .attemptExceeded
+                return .cancel(id: CancelID.timer)
+
+            case .verifyResponse(.dailyExceeded):
+                state.isVerifying = false
+                state.alert = .dailyExceeded
+                return .cancel(id: CancelID.timer)
+
+            // MARK: Resend
+
+            case .resendTapped:
+                guard state.isResendEnabled else { return .none }
+                state.isResending = true
+                state.resendCount += 1
+                let email = state.maskedEmail   // TODO: [백엔드 연동] 원본 이메일로 교체 (현재는 마스킹값 전달)
+                return .run { [client] send in
+                    await send(.resendResponse(try await client.resend(email)))
+                }
+                .cancellable(id: CancelID.resend, cancelInFlight: true)
+
+            case .resendResponse(.sent):
+                // 입력 초기화 + 새 3분 타이머
+                state.isResending = false
+                state.code = ""
+                state.inputState = .idle
+                state.bottomMessage = .resent
+                state.remainingSeconds = Policy.totalSeconds
+                state.isTimerRunning = true
+                return .merge(
+                    .cancel(id: CancelID.timer),
+                    .run { [clock] send in
+                        for await _ in clock.timer(interval: .seconds(1)) {
+                            await send(.timerTicked)
+                        }
+                    }
+                    .cancellable(id: CancelID.timer, cancelInFlight: true)
+                )
+
+            case .resendResponse(.resendExceeded):
+                state.isResending = false
+                state.alert = .resendExceeded
+                return .cancel(id: CancelID.timer)
+
+            case .resendResponse(.dailyExceeded):
+                state.isResending = false
+                state.alert = .dailyExceeded
+                return .cancel(id: CancelID.timer)
+
+            // MARK: Alert
+
+            case .alertConfirmed:
+                let kind = state.alert
+                state.alert = nil
+                switch kind {
+                case .resendExceeded, .dailyExceeded:
+                    return .send(.delegate(.popToFindAccount))
+                case .successEmailSignup, .successSocialSignup:
+                    // 인증 성공 → 로그인 화면으로 이동 (FindAccount → CredentialLogin 단계까지 dismiss)
+                    return .send(.delegate(.navigateToLogin))
+                case .timeExpired, .attemptExceeded, .none:
+                    // 모달만 닫고 같은 화면 유지 (사용자가 새 인증번호 요청 가능)
+                    return .none
+                }
+
+            // MARK: Navigation
+
+            case .backButtonTapped:
+                return .merge(
+                    .cancel(id: CancelID.timer),
+                    .cancel(id: CancelID.verify),
+                    .cancel(id: CancelID.resend),
+                    .send(.delegate(.popToFindAccount))
+                )
+
+            case .delegate:
+                return .none
+            }
+        }
+    }
+}

--- a/Projects/Feature/Onboarding/Sources/Login/FindAccount/VerificationCode/VerificationCodeView.swift
+++ b/Projects/Feature/Onboarding/Sources/Login/FindAccount/VerificationCode/VerificationCodeView.swift
@@ -1,0 +1,287 @@
+import SwiftUI
+import ComposableArchitecture
+import SharedDesignSystem
+
+public struct VerificationCodeView: View {
+    @Bindable public var store: StoreOf<VerificationCodeFeature>
+
+    public init(store: StoreOf<VerificationCodeFeature>) {
+        self.store = store
+    }
+
+    public var body: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                CustomNavigationBar(
+                    title: "인증번호 입력",
+                    onBack: { store.send(.backButtonTapped) }
+                )
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        header
+                            .padding(.top, 18)   // 네비게이션 바와의 간격
+                        VerificationCodeInputField(
+                            text: $store.code,
+                            isError: store.inputState == .error
+                        )
+                        .padding(.top, 21)       // 헤더와의 간격
+                        codeMismatchSlot         // 입력 필드 ↔ 인증 확인 버튼 사이 고정 46pt 슬롯
+                        verifyButton
+                        timerRow
+                            .padding(.top, 24)   // 인증 확인 버튼과의 간격
+                        resentNotice             // 남은 시간 라벨 아래 8pt
+                    }
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 20)
+                }
+                .scrollDismissesKeyboard(.interactively)
+
+                Spacer(minLength: 0)
+            }
+            .background(Color.gray50)
+            .onAppear { store.send(.onAppear) }
+            .dismissKeyboardOnTap()
+
+            if let alert = store.alert {
+                alertOverlay(for: alert)
+            }
+        }
+        .onChange(of: store.alert == nil) { _, isClosed in
+            // alert이 새로 뜨는 순간 키보드 내림 — alert이 자연스럽게 화면 정중앙에 표시되도록.
+            if !isClosed {
+                dismissKeyboard()
+            }
+        }
+    }
+
+    /// 현재 first responder를 resign하여 키보드를 내림.
+    private func dismissKeyboard() {
+        UIApplication.shared.sendAction(
+            #selector(UIResponder.resignFirstResponder),
+            to: nil, from: nil, for: nil
+        )
+    }
+
+    // MARK: - Header
+
+    /// 마스킹된 이메일은 body5, 안내 문구는 body8로 톤 분리.
+    private var header: some View {
+        (Text(store.maskedEmail).typographyText(.body5)
+         + Text(" 으로\n발송된 인증번호를 입력해주세요.").typographyText(.body8))
+            .foregroundStyle(Color.gray800)
+            .typographyLineSpacing(.body8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: - Verify Button
+
+    private var verifyButton: some View {
+        PrimaryButton(title: "인증 확인", isEnabled: store.isVerifyEnabled) {
+            store.send(.verifyTapped)
+        }
+    }
+
+    // MARK: - Timer Row
+
+    private var timerRow: some View {
+        HStack(spacing: 0) {
+            Text("남은 시간 \(store.formattedTime)")
+                .typography(.body11)
+                .foregroundStyle(Color.error)
+
+            Spacer()
+
+            Button {
+                store.send(.resendTapped)
+            } label: {
+                Text("재전송")
+                    .typography(.label1)
+                    .foregroundStyle(store.isResendEnabled ? Color.primary500 : Color.gray400)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 8)
+                    .overlay(
+                        Capsule().stroke(
+                            store.isResendEnabled ? Color.primary500 : Color.gray300,
+                            lineWidth: 1
+                        )
+                    )
+            }
+            .disabled(!store.isResendEnabled)
+        }
+    }
+
+    // MARK: - Inline Messages
+
+    /// 입력 필드와 인증 확인 버튼 사이 고정 46pt 영역.
+    /// 코드 불일치 메시지가 있을 때만 안에 표시되고, 메시지 유무에 따라 버튼 위치는 변하지 않는다.
+    /// 글씨체/색상은 남은 시간 라벨과 동일(body11 + error). 좌측에 ⚠ 아이콘 동반.
+    private var codeMismatchSlot: some View {
+        ZStack(alignment: .leading) {
+            Color.clear.frame(maxWidth: .infinity).frame(height: 46)
+            if case .codeMismatch(let remaining) = store.bottomMessage {
+                HStack(spacing: 7) {
+                    Image(systemName: "info.circle")
+                        .foregroundStyle(Color.error)
+                    Text("인증번호를 정확히 입력해주세요. (\(remaining)회 남음)")
+                        .typography(.body11)
+                        .foregroundStyle(Color.error)
+                }
+            }
+        }
+    }
+
+    /// 남은 시간 라벨 아래 8pt에 노출되는 재전송 안내 메시지..
+    @ViewBuilder
+    private var resentNotice: some View {
+        if case .resent = store.bottomMessage {
+            Text("인증번호가 재전송되었어요. 메일함을 확인해주세요")
+                .typography(.body11)
+                .foregroundStyle(Color.error)
+                .padding(.top, 8)
+        }
+    }
+
+    // MARK: - Alert Overlay
+
+    @ViewBuilder
+    private func alertOverlay(for alert: VerificationCodeFeature.AlertKind) -> some View {
+        switch alert {
+        case .timeExpired:
+            CustomAlert(
+                title: "인증 시간이 초과되었어요.\n다시 시도해주세요.",
+                primaryButtonTitle: "확인",
+                primaryAction: { store.send(.alertConfirmed) }
+            )
+        case .attemptExceeded:
+            CustomAlert(
+                title: "입력 횟수(5회)를 초과했어요.\n인증번호를 다시 요청해주세요.",
+                primaryButtonTitle: "확인",
+                primaryAction: { store.send(.alertConfirmed) }
+            )
+        case .resendExceeded:
+            CustomAlert(
+                title: "인증번호 재발송횟수(5회)를 초과했어요.\n24시간 뒤에 다시 시도하세요.",
+                primaryButtonTitle: "돌아가기",
+                primaryAction: { store.send(.alertConfirmed) }
+            )
+        case .dailyExceeded:
+            CustomAlert(
+                title: "일일 인증 요청(10회)를 초과했어요.\n24시간 뒤에 다시 시도하세요.",
+                primaryButtonTitle: "돌아가기",
+                primaryAction: { store.send(.alertConfirmed) }
+            )
+        case .successEmailSignup(let maskedId):
+            CustomAlert(
+                title: "이메일로 가입하신 아이디를 보냈어요.",
+                description: "개인정보 보호를 위해 화면에는 일부만 표시해요.\n메일함에서 전체 아이디를 확인해주세요.",
+                primaryButtonTitle: "로그인 하러가기",
+                primaryAction: { store.send(.alertConfirmed) }
+            ) {
+                Text("( 아이디 : \(maskedId) )")
+                    .typography(.body6)
+                    .foregroundStyle(Color.primary500)
+            }
+        case .successSocialSignup(let provider):
+            CustomAlert(
+                title: "이미 \(provider.displayName)로 가입한 계정이에요.",
+                description: "\(provider.displayName)로 로그인 해주세요.",
+                primaryButtonTitle: "\(provider.displayName) 로그인",
+                primaryAction: { store.send(.alertConfirmed) }
+            )
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("기본") {
+    VerificationCodeView(
+        store: .init(
+            initialState: VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com"),
+            reducer: { VerificationCodeFeature() }
+        )
+    )
+}
+
+#Preview("입력 중 (2자)") {
+    VerificationCodeView(
+        store: .init(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "22"
+                return s
+            }(),
+            reducer: { VerificationCodeFeature() }
+        )
+    )
+}
+
+#Preview("재전송 활성 + 안내") {
+    VerificationCodeView(
+        store: .init(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "22"
+                s.remainingSeconds = 120
+                s.bottomMessage = .resent
+                return s
+            }(),
+            reducer: { VerificationCodeFeature() }
+        )
+    )
+}
+
+#Preview("코드 오류") {
+    VerificationCodeView(
+        store: .init(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "225485"
+                s.inputState = .error
+                s.bottomMessage = .codeMismatch(remaining: 4)
+                return s
+            }(),
+            reducer: { VerificationCodeFeature() }
+        )
+    )
+}
+
+#Preview("Alert - 시간 초과") {
+    VerificationCodeView(
+        store: .init(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.alert = .timeExpired
+                return s
+            }(),
+            reducer: { VerificationCodeFeature() }
+        )
+    )
+}
+
+#Preview("Alert - 인증성공 이메일") {
+    VerificationCodeView(
+        store: .init(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.alert = .successEmailSignup(maskedId: "tto***")
+                return s
+            }(),
+            reducer: { VerificationCodeFeature() }
+        )
+    )
+}
+
+#Preview("Alert - 인증성공 카카오") {
+    VerificationCodeView(
+        store: .init(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.alert = .successSocialSignup(provider: .kakao)
+                return s
+            }(),
+            reducer: { VerificationCodeFeature() }
+        )
+    )
+}

--- a/Projects/Feature/Onboarding/Sources/Signup/SignupFeature.swift
+++ b/Projects/Feature/Onboarding/Sources/Signup/SignupFeature.swift
@@ -17,6 +17,9 @@ public struct SignupFeature: Reducer {
     
     @ObservableState
     public struct State: Equatable {
+        /// 회원가입 정보 입력 완료 후 push되는 약관동의 화면
+        @Presents public var termsAgreement: TermsAgreementFeature.State?
+
         // MARK: - 입력값
         public var id: String = ""
         public var password: String = ""
@@ -123,36 +126,49 @@ public struct SignupFeature: Reducer {
     
     public enum Action: BindableAction {
         case binding(BindingAction<State>)
-        
+
         // 네비게이션
         case backButtonTapped
-        
+
         // 아이디
         case checkDuplicateIdTapped
         case checkDuplicateIdResponse(DuplicateCheckResult)
         case clearIdTapped
-        
-        
+
+
         // 비밀번호
         case togglePasswordVisibility
         case togglePasswordConfirmVisibility
         case clearPasswordTapped
         case clearPasswordConfirmTapped
-        
+
         // 이메일
         case clearEmailTapped
-        
+
         // 닉네임
         case checkDuplicateNicknameTapped
         case checkDuplicateNicknameResponse(DuplicateCheckResult)
         case clearNicknameTapped
-        
+
         // 회원가입
         case signUpTapped
-        
+
         // 로그인 하러가기
         case loginLinkTapped
-        
+
+        /// 약관동의 화면 위임 액션
+        case termsAgreement(PresentationAction<TermsAgreementFeature.Action>)
+
+        // 부모(CredentialLogin)에 전달할 위임 이벤트
+        case delegate(Delegate)
+
+        @CasePathable
+        public enum Delegate: Equatable {
+            /// "로그인 하러가기" 탭 또는 약관동의 X 탭 — 회원가입 플로우 종료, 로그인 화면으로 복귀
+            case navigateToLogin
+            /// 약관동의·보호자 상태 선택까지 완료 — 회원가입 전체 플로우 종료, 메인 진입(미정)
+            case signupFlowCompleted
+        }
     }
 
     // MARK: - Reducer
@@ -167,8 +183,8 @@ public struct SignupFeature: Reducer {
                 return .none
                 
             case .backButtonTapped:
-                // TODO: 네비게이션 뒤로가기 액션처리
-                return .none
+                // 회원가입 화면 뒤로가기 → 작성 데이터 폐기 + 로그인 화면 복귀
+                return .send(.delegate(.navigateToLogin))
                 
             case .checkDuplicateIdTapped:
                 // TODO: 아이디 중복확인 API 연결
@@ -215,18 +231,34 @@ public struct SignupFeature: Reducer {
                 return .none
                 
             case .signUpTapped:
-                // TODO: 회원가입 액션처리
+                // 정보 입력 후 "다음으로" → 약관동의 화면 push
+                state.termsAgreement = TermsAgreementFeature.State()
+                return .none
+
+            case .termsAgreement(.presented(.delegate(.closeTapped))):
+                // 약관동의 X → 회원가입 작성 데이터 폐기 + 로그인 화면 복귀
+                state.termsAgreement = nil
+                return .send(.delegate(.navigateToLogin))
+
+            case .termsAgreement(.presented(.delegate(.signupFlowCompleted))):
+                state.termsAgreement = nil
+                return .send(.delegate(.signupFlowCompleted))
+
+            case .termsAgreement:
                 return .none
                 
             case .loginLinkTapped:
-                // TODO: 로그인하러가기 액션처리
+                return .send(.delegate(.navigateToLogin))
+
+            case .delegate:
                 return .none
             }
-            
+
         }
-        
-        
+        .ifLet(\.$termsAgreement, action: \.termsAgreement) {
+            TermsAgreementFeature()
+        }
     }
-    
+
 }
 

--- a/Projects/Feature/Onboarding/Sources/Signup/SignupView.swift
+++ b/Projects/Feature/Onboarding/Sources/Signup/SignupView.swift
@@ -14,7 +14,10 @@ public struct SignupView: View {
     
     public var body: some View {
         VStack(spacing: 0) {
-            CustomNavigationBar(title: "회원가입", onBack: { })
+            CustomNavigationBar(
+                title: "회원가입",
+                onBack: { store.send(.backButtonTapped) }
+            )
             
             ScrollView {
                 VStack(alignment: .leading, spacing: 30) {
@@ -118,17 +121,26 @@ public struct SignupView: View {
                     
                 }
                 .padding(20)
-                
+
             } // 스크롤 블록
+            .scrollDismissesKeyboard(.interactively)   // 스크롤 시 키보드 자연 dismiss
             
             // MARK: - 하단 뷰
             SignUpBottomView(
                 isNextButtonEnabled: store.isSignUpEnabled,
-                loginLinkAction: { },
-                nextButtonAction: { }
+                loginLinkAction: { store.send(.loginLinkTapped) },
+                nextButtonAction: { store.send(.signUpTapped) }
             )
-            
-            
+
+
+        }
+        .background(Color.gray50)   // 다크모드에서도 일관된 배경 유지 (다른 온보딩 화면과 동일 톤)
+        .dismissKeyboardOnTap()
+        .navigationDestination(
+            item: $store.scope(state: \.termsAgreement, action: \.termsAgreement)
+        ) { termsStore in
+            TermsAgreementView(store: termsStore)
+                .navigationBarBackButtonHidden()
         }
     }
 }

--- a/Projects/Feature/Onboarding/Sources/TermsAgreement/TermsAgreementFeature.swift
+++ b/Projects/Feature/Onboarding/Sources/TermsAgreement/TermsAgreementFeature.swift
@@ -17,7 +17,10 @@ public struct TermsAgreementFeature: Reducer {
         public var isAgeChecked: Bool = false          // [필수] 만 14세 이상
         public var isLocationChecked: Bool = false     // [선택] 위치정보
         public var isMarketingChecked: Bool = false    // [선택] 마케팅 수신
-        
+
+        /// 약관 동의 후 push되는 보호자 상태 선택 화면
+        @Presents public var guardianStatus: GuardianStatusFeature.State?
+
         // 필수 약관 모두 동의 여부 (가입 버튼 활성화 조건)
         public var isRequiredAllChecked: Bool {
             isTermsChecked &&
@@ -25,7 +28,7 @@ public struct TermsAgreementFeature: Reducer {
             isThirdPartyChecked &&
             isAgeChecked
         }
-        
+
         public init() { }
     }
     
@@ -35,13 +38,17 @@ public struct TermsAgreementFeature: Reducer {
         case allCheckToggled // 전체동의 탭
         case signupButtonTapped // 동의하고 가입하기 탭
         case closeButtonTapped // 네비게이션 닫기 탭
+        /// 보호자 상태 선택 화면 위임 액션
+        case guardianStatus(PresentationAction<GuardianStatusFeature.Action>)
         case delegate(Delegate)
         // TODO: 보기 액션 추가
-        
-        
+
+
+        @CasePathable
         public enum Delegate: Equatable {
-            case signupCompleted
             case closeTapped
+            /// 보호자 상태 선택까지 완료 — 회원가입 플로우 다음 단계로 진행 (현재 미정)
+            case signupFlowCompleted
         }
     }
     
@@ -70,18 +77,32 @@ public struct TermsAgreementFeature: Reducer {
                 guard state.isRequiredAllChecked else {
                     return .none
                 }
-                
-                return Effect.send(.delegate(.signupCompleted))
-                
-            case .delegate(_):
+                state.guardianStatus = GuardianStatusFeature.State()
                 return .none
+
+            case .guardianStatus(.presented(.delegate(.backTapped))):
+                state.guardianStatus = nil
+                return .none
+
+            case .guardianStatus(.presented(.delegate(.startCompleted))):
+                // TODO: 회원가입 다음 단계 연결 (e.g., SignupView 입력 또는 가입 완료 후 메인 진입)
+                state.guardianStatus = nil
+                return .send(.delegate(.signupFlowCompleted))
+
+            case .guardianStatus:
+                return .none
+
+            case .delegate:
+                return .none
+
             case .closeButtonTapped:
                 return Effect.send(.delegate(.closeTapped))
             }
-            
+
+        }
+        .ifLet(\.$guardianStatus, action: \.guardianStatus) {
+            GuardianStatusFeature()
         }
     }
-    
-    
 }
 

--- a/Projects/Feature/Onboarding/Sources/TermsAgreement/TermsAgreementView.swift
+++ b/Projects/Feature/Onboarding/Sources/TermsAgreement/TermsAgreementView.swift
@@ -7,7 +7,7 @@ import SharedDesignSystem
 public struct TermsAgreementView: View {
     
     // MARK: - Properties
-    public var store: StoreOf<TermsAgreementFeature>
+    @Bindable public var store: StoreOf<TermsAgreementFeature>
     
     // MARK: - init
     public init(store: StoreOf<TermsAgreementFeature>) {
@@ -46,8 +46,15 @@ public struct TermsAgreementView: View {
             .padding(.horizontal, 20)
             .padding(.bottom, 16)
         }
+        .background(Color.gray50)   // 다크모드에서도 일관된 배경 유지
+        .navigationDestination(
+            item: $store.scope(state: \.guardianStatus, action: \.guardianStatus)
+        ) { guardianStore in
+            GuardianStatusView(store: guardianStore)
+                .navigationBarBackButtonHidden()
+        }
     }
-    
+
     // MARK: - Terms Agreement All Check Row (전체동의)
     private var termsAgreementAllCheckRow: some View {
         HStack(spacing: 8) {

--- a/Projects/Feature/Onboarding/Sources/Tutorial/TutorialView.swift
+++ b/Projects/Feature/Onboarding/Sources/Tutorial/TutorialView.swift
@@ -62,16 +62,8 @@ public struct TutorialView: View {
 
     // TODO: 똑독 시작하기 탭 시 튜토리얼 완료 후 이동할 화면 연결
     private var startButton: some View {
-        Button {
+        PrimaryButton(title: "똑독 시작하기", height: 70) {
             store.send(.startTapped)
-        } label: {
-            Text("똑독 시작하기")
-                .typography(.buttonL)
-                .foregroundStyle(.white)
-                .frame(maxWidth: .infinity)
-                .frame(height: 70)
-                .background(Color.primary500)
-                .clipShape(RoundedRectangle(cornerRadius: 14))
         }
     }
 

--- a/Projects/Feature/Onboarding/Tests/Sources/VerificationCodeTests.swift
+++ b/Projects/Feature/Onboarding/Tests/Sources/VerificationCodeTests.swift
@@ -1,0 +1,524 @@
+import Testing
+import ComposableArchitecture
+@testable import FeatureOnboarding
+
+@MainActor
+struct VerificationCodeTests {
+
+    // MARK: - Initial State
+
+    @Test
+    func initialState_기본값() async {
+        let state = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+        #expect(state.code == "")
+        #expect(state.remainingSeconds == 180)
+        #expect(state.attemptCount == 0)
+        #expect(state.resendCount == 0)
+        #expect(state.inputState == .idle)
+        #expect(state.bottomMessage == nil)
+        #expect(state.alert == nil)
+        #expect(state.formattedTime == "03:00")
+        #expect(state.isCodeFilled == false)
+        #expect(state.isVerifyEnabled == false)
+    }
+
+    // MARK: - Code Binding
+
+    @Test
+    func code_바인딩_숫자만_6자_cap() async {
+        let store = TestStore(
+            initialState: VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+        ) {
+            VerificationCodeFeature()
+        }
+
+        // 알파벳 + 숫자 혼합, 6자 초과 → 숫자만 6자로 잘려야 함
+        await store.send(\.binding.code, "abc1234567") {
+            $0.code = "123456"
+        }
+    }
+
+    @Test
+    func code_재입력_시_에러상태_해제() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "123456"
+                s.inputState = .error
+                s.bottomMessage = .codeMismatch(remaining: 4)
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        }
+
+        await store.send(\.binding.code, "1234") {
+            $0.code = "1234"
+            $0.inputState = .idle
+            $0.bottomMessage = nil
+        }
+    }
+
+    // MARK: - Timer
+
+    @Test
+    func 타이머_초당_remainingSeconds_감소() async {
+        let clock = TestClock()
+        let store = TestStore(
+            initialState: VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.continuousClock = clock
+        }
+
+        await store.send(.onAppear) { $0.isTimerRunning = true }
+
+        await clock.advance(by: .seconds(1))
+        await store.receive(\.timerTicked) { $0.remainingSeconds = 179 }
+
+        await clock.advance(by: .seconds(1))
+        await store.receive(\.timerTicked) { $0.remainingSeconds = 178 }
+
+        // 정리 — 타이머 cancel + delegate
+        await store.send(.backButtonTapped)
+        await store.receive(\.delegate.popToFindAccount)
+    }
+
+    @Test
+    func 타이머_만료_시_timeExpired_alert() async {
+        let clock = TestClock()
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.remainingSeconds = 1
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.continuousClock = clock
+        }
+
+        await store.send(.onAppear) { $0.isTimerRunning = true }
+
+        await clock.advance(by: .seconds(1))
+        await store.receive(\.timerTicked) {
+            $0.remainingSeconds = 0
+            $0.isTimerRunning = false
+            $0.alert = .timeExpired
+        }
+    }
+
+    // MARK: - Derived 활성화 조건
+
+    @Test
+    func 재전송버튼_2분이전엔_비활성화() {
+        var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+        s.remainingSeconds = 121
+        #expect(s.isResendEnabled == false)
+    }
+
+    @Test
+    func 재전송버튼_2분이하면_활성화() {
+        var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+        s.remainingSeconds = 120
+        #expect(s.isResendEnabled == true)
+    }
+
+    @Test
+    func 재전송_5회_도달_시_재전송버튼_비활성화() {
+        var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+        s.remainingSeconds = 60
+        s.resendCount = 5
+        #expect(s.isResendEnabled == false)
+    }
+
+    @Test
+    func 인증버튼_6자_미만_비활성화() {
+        var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+        s.code = "12345"
+        #expect(s.isVerifyEnabled == false)
+    }
+
+    @Test
+    func 인증버튼_에러상태_시_비활성화() {
+        var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+        s.code = "123456"
+        s.inputState = .error
+        #expect(s.isVerifyEnabled == false)
+    }
+
+    // MARK: - Verify Mismatch
+
+    @Test
+    func verify_mismatch_응답_시_n회남음과_에러상태() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "000000"
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.verificationCodeClient.verify = { _, _ in .mismatch }
+        }
+
+        await store.send(.verifyTapped) {
+            $0.isVerifying = true
+            $0.attemptCount = 1
+        }
+        await store.receive(\.verifyResponse) {
+            $0.isVerifying = false
+            $0.inputState = .error
+            $0.bottomMessage = .codeMismatch(remaining: 4)
+        }
+    }
+
+    @Test
+    func 입력_5회_실패_시_attemptExceeded_alert() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "000000"
+                s.attemptCount = 4
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.verificationCodeClient.verify = { _, _ in .mismatch }
+        }
+
+        await store.send(.verifyTapped) {
+            $0.isVerifying = true
+            $0.attemptCount = 5
+        }
+        await store.receive(\.verifyResponse) {
+            $0.isVerifying = false
+            $0.inputState = .error
+            $0.bottomMessage = .codeMismatch(remaining: 0)
+            $0.alert = .attemptExceeded
+        }
+    }
+
+    @Test
+    func verify_진행중_재탭_시_attemptCount_중복증가_방지() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "000000"
+                s.isVerifying = true   // 이미 진행 중
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        }
+
+        // isVerifying이 true이므로 isVerifyEnabled는 false → guard에서 차단
+        await store.send(.verifyTapped)
+        // 상태 변화 없음 (attemptCount 그대로 0)
+    }
+
+    // MARK: - Verify Success / Server-side limit
+
+    @Test
+    func verify_successEmailSignup_응답_시_alert_표시와_타이머_중단() async {
+        let clock = TestClock()
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "123456"
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.continuousClock = clock
+            $0.verificationCodeClient.verify = { _, _ in .successEmailSignup(maskedId: "tto***") }
+        }
+
+        await store.send(.verifyTapped) {
+            $0.isVerifying = true
+            $0.attemptCount = 1
+        }
+        await store.receive(\.verifyResponse) {
+            $0.isVerifying = false
+            $0.alert = .successEmailSignup(maskedId: "tto***")
+            $0.isTimerRunning = false
+        }
+    }
+
+    @Test
+    func verify_successSocialSignup_응답_시_alert_표시() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "123456"
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.verificationCodeClient.verify = { _, _ in .successSocialSignup(provider: .kakao) }
+        }
+
+        await store.send(.verifyTapped) {
+            $0.isVerifying = true
+            $0.attemptCount = 1
+        }
+        await store.receive(\.verifyResponse) {
+            $0.isVerifying = false
+            $0.alert = .successSocialSignup(provider: .kakao)
+            $0.isTimerRunning = false
+        }
+    }
+
+    @Test
+    func verify_서버_attemptExceeded_응답_시_alert() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "123456"
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.verificationCodeClient.verify = { _, _ in .attemptExceeded }
+        }
+
+        await store.send(.verifyTapped) {
+            $0.isVerifying = true
+            $0.attemptCount = 1
+        }
+        await store.receive(\.verifyResponse) {
+            $0.isVerifying = false
+            $0.alert = .attemptExceeded
+        }
+    }
+
+    @Test
+    func verify_서버_dailyExceeded_응답_시_alert() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.code = "123456"
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.verificationCodeClient.verify = { _, _ in .dailyExceeded }
+        }
+
+        await store.send(.verifyTapped) {
+            $0.isVerifying = true
+            $0.attemptCount = 1
+        }
+        await store.receive(\.verifyResponse) {
+            $0.isVerifying = false
+            $0.alert = .dailyExceeded
+        }
+    }
+
+    // MARK: - Resend
+
+    @Test
+    func resend_sent_응답_시_타이머_리셋_및_코드_초기화() async {
+        let clock = TestClock()
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.remainingSeconds = 60
+                s.code = "1234"
+                s.inputState = .error
+                s.bottomMessage = .codeMismatch(remaining: 3)
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.continuousClock = clock
+            $0.verificationCodeClient.resend = { _ in .sent }
+        }
+
+        await store.send(.resendTapped) {
+            $0.isResending = true
+            $0.resendCount = 1
+        }
+        await store.receive(\.resendResponse) {
+            $0.isResending = false
+            $0.code = ""
+            $0.inputState = .idle
+            $0.remainingSeconds = 180
+            $0.bottomMessage = .resent
+            $0.isTimerRunning = true
+        }
+
+        await store.send(.backButtonTapped)
+        await store.receive(\.delegate.popToFindAccount)
+    }
+
+    @Test
+    func resend_resendExceeded_응답_시_alert() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.remainingSeconds = 60
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.verificationCodeClient.resend = { _ in .resendExceeded }
+        }
+
+        await store.send(.resendTapped) {
+            $0.isResending = true
+            $0.resendCount = 1
+        }
+        await store.receive(\.resendResponse) {
+            $0.isResending = false
+            $0.alert = .resendExceeded
+        }
+    }
+
+    @Test
+    func resend_dailyExceeded_응답_시_alert() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.remainingSeconds = 60
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        } withDependencies: {
+            $0.verificationCodeClient.resend = { _ in .dailyExceeded }
+        }
+
+        await store.send(.resendTapped) {
+            $0.isResending = true
+            $0.resendCount = 1
+        }
+        await store.receive(\.resendResponse) {
+            $0.isResending = false
+            $0.alert = .dailyExceeded
+        }
+    }
+
+    @Test
+    func resend_진행중_재탭_시_resendCount_중복증가_방지() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.remainingSeconds = 60
+                s.isResending = true
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        }
+
+        // isResending이 true이므로 isResendEnabled는 false → guard에서 차단
+        await store.send(.resendTapped)
+    }
+
+    // MARK: - Alert Confirmed
+
+    @Test
+    func alertConfirmed_timeExpired_시_모달만_닫음() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.alert = .timeExpired
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        }
+
+        await store.send(.alertConfirmed) { $0.alert = nil }
+    }
+
+    @Test
+    func alertConfirmed_attemptExceeded_시_모달만_닫음() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.alert = .attemptExceeded
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        }
+
+        await store.send(.alertConfirmed) { $0.alert = nil }
+    }
+
+    @Test
+    func alertConfirmed_resendExceeded_시_pop() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.alert = .resendExceeded
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        }
+
+        await store.send(.alertConfirmed) { $0.alert = nil }
+        await store.receive(\.delegate.popToFindAccount)
+    }
+
+    @Test
+    func alertConfirmed_dailyExceeded_시_pop() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.alert = .dailyExceeded
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        }
+
+        await store.send(.alertConfirmed) { $0.alert = nil }
+        await store.receive(\.delegate.popToFindAccount)
+    }
+
+    @Test
+    func alertConfirmed_successEmail_시_navigateToLogin_위임() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.alert = .successEmailSignup(maskedId: "tto***")
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        }
+
+        await store.send(.alertConfirmed) { $0.alert = nil }
+        await store.receive(\.delegate.navigateToLogin)
+    }
+
+    @Test
+    func alertConfirmed_successSocial_시_navigateToLogin_위임() async {
+        let store = TestStore(
+            initialState: {
+                var s = VerificationCodeFeature.State(maskedEmail: "tto****@gmail.com")
+                s.alert = .successSocialSignup(provider: .kakao)
+                return s
+            }()
+        ) {
+            VerificationCodeFeature()
+        }
+
+        await store.send(.alertConfirmed) { $0.alert = nil }
+        await store.receive(\.delegate.navigateToLogin)
+    }
+}

--- a/Projects/Shared/DesignSystem/Sources/Components/CustomAlert.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/CustomAlert.swift
@@ -90,26 +90,20 @@ public struct CustomAlert<Content: View>: View {
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
 
-                Button(action: primaryAction) {
-                    Text(primaryButtonTitle)
-                        .typography(.buttonL)
-                        .foregroundStyle(.white)
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 54)
-                        .background(Color.primary500)
-                        .clipShape(RoundedRectangle(cornerRadius: 12))
-                }
+                PrimaryButton(
+                    title: primaryButtonTitle,
+                    height: 54,
+                    cornerRadius: 12,
+                    action: primaryAction
+                )
             }
         } else {
-            Button(action: primaryAction) {
-                Text(primaryButtonTitle)
-                    .typography(.buttonL)
-                    .foregroundStyle(.white)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 54)
-                    .background(Color.primary500)
-                    .clipShape(RoundedRectangle(cornerRadius: 12))
-            }
+            PrimaryButton(
+                title: primaryButtonTitle,
+                height: 54,
+                cornerRadius: 12,
+                action: primaryAction
+            )
         }
     }
 }

--- a/Projects/Shared/DesignSystem/Sources/Components/CustomNavigationBar.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/CustomNavigationBar.swift
@@ -34,7 +34,7 @@ public struct CustomNavigationBar: View {
             trailingView
         }
         .frame(height: 50)
-        .padding(.horizontal, 16)
+        .padding(.horizontal, 10)
     }
 
     @ViewBuilder

--- a/Projects/Shared/DesignSystem/Sources/Components/PrimaryButton.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/PrimaryButton.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// 똑독 메인 CTA(Call To Action) 버튼.
+///
+/// 화면 하단의 주요 액션 버튼(예: "로그인", "다음으로", "인증 확인", "똑독 시작하기")에 일관되게 사용한다.
+/// - 활성 상태: `primary500` 배경 + `white` 텍스트
+/// - 비활성 상태: `gray300` 배경 + `gray400` 텍스트 + 탭 비활성화
+///
+/// ## 사용법
+/// ```swift
+/// PrimaryButton(title: "다음으로", isEnabled: state.isValid) {
+///     store.send(.nextTapped)
+/// }
+///
+/// // 높이/코너 반경을 조정해야 하는 경우
+/// PrimaryButton(title: "똑독 시작하기", height: 70) { ... }
+/// ```
+public struct PrimaryButton: View {
+    private let title: String
+    private let isEnabled: Bool
+    private let height: CGFloat
+    private let cornerRadius: CGFloat
+    private let action: () -> Void
+
+    public init(
+        title: String,
+        isEnabled: Bool = true,
+        height: CGFloat = 60,
+        cornerRadius: CGFloat = 15,
+        action: @escaping () -> Void
+    ) {
+        self.title = title
+        self.isEnabled = isEnabled
+        self.height = height
+        self.cornerRadius = cornerRadius
+        self.action = action
+    }
+
+    public var body: some View {
+        Button(action: action) {
+            Text(title)
+                .typography(.buttonL)
+                .foregroundStyle(isEnabled ? Color.white : Color.gray400)
+                .frame(maxWidth: .infinity)
+                .frame(height: height)
+                .background(isEnabled ? Color.primary500 : Color.gray300)
+                .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+        }
+        .disabled(!isEnabled)
+    }
+}
+
+// MARK: - Preview
+
+#Preview("활성 - 기본 (60)") {
+    PrimaryButton(title: "다음으로") {}
+        .padding(20)
+}
+
+#Preview("비활성 - 기본 (60)") {
+    PrimaryButton(title: "다음으로", isEnabled: false) {}
+        .padding(20)
+}
+
+#Preview("활성 - 큰 사이즈 (70)") {
+    PrimaryButton(title: "똑독 시작하기", height: 70) {}
+        .padding(20)
+}
+
+#Preview("활성 - 작은 사이즈 (54, cornerRadius 12)") {
+    PrimaryButton(title: "확인", height: 54, cornerRadius: 12) {}
+        .padding(20)
+}

--- a/Projects/Shared/DesignSystem/Sources/Components/View+KeyboardDismiss.swift
+++ b/Projects/Shared/DesignSystem/Sources/Components/View+KeyboardDismiss.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+import UIKit
+
+public extension View {
+    /// 빈 영역 탭 시 first responder를 resign하여 키보드를 내린다.
+    ///
+    /// 온보딩/입력 화면 등 텍스트 입력이 있는 화면에서 일관된 키보드 dismiss 동작을 보장하기 위해 사용한다.
+    /// 입력 필드/버튼 등의 자체 gesture는 그대로 동작하며 빈 영역 탭에만 반응한다.
+    ///
+    /// ## 사용법
+    /// ```swift
+    /// VStack { ... }
+    ///     .background(Color.gray50)
+    ///     .dismissKeyboardOnTap()
+    /// ```
+    func dismissKeyboardOnTap() -> some View {
+        onTapGesture {
+            UIApplication.shared.sendAction(
+                #selector(UIResponder.resignFirstResponder),
+                to: nil, from: nil, for: nil
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Related Issue

- #42

## Background

아이디 찾기에서 \"인증번호 전송\" 다음 단계로 6자리 인증번호 입력 화면을 추가합니다. 작업 과정에서 회원가입 → 약관동의 → 보호자 상태 선택까지 이어지는 온보딩 푸시 체인을 정리하고, 화면 간 시각/동작 일관성(키보드 dismiss · 배경 톤 · CTA 버튼 컴포넌트)을 함께 맞췄습니다.

## Contents

### 인증번호 입력 화면 (#42 핵심)

- **`VerificationCodeFeature`** — 6자리 검증/재전송, 3분 타이머, 입력·재전송 한도(5/5/10), 결과 alert 분기, 진행 중 연타 방지(\`isVerifying\` · \`isResending\`), 화면 dismiss 시 모든 effect cancel
- **`VerificationCodeClient`** — 백엔드 미연동 단계 stub (\`123456\` → successEmailSignup)
- **`VerificationCodeInputField`** — 6박스 + 숨김 \`TextField\`, \`textContentType(.oneTimeCode)\` 자동완성 + 60ms staggered 채움 효과, View 단 입력 정제(숫자 6자 cap)
- **`VerificationCodeView`** — 시안 7가지 상태 매핑(기본/입력 중/재전송 활성/코드 오류/한도 alert/시간 만료/인증 성공)
- **테스트** — Swift Testing + TestStore + TestClock 기반 27개 회귀 테스트

```swift
// VerificationCodeFeature.swift — 핵심 effect 정리
case .backButtonTapped:
    return .merge(
        .cancel(id: CancelID.timer),
        .cancel(id: CancelID.verify),
        .cancel(id: CancelID.resend),
        .send(.delegate(.popToFindAccount))
    )
```

### 디자인 시스템 컴포넌트 추가

- **\`PrimaryButton\`** (SharedDesignSystem) — 메인 CTA를 단일 컴포넌트로 통일. \`height\` · \`cornerRadius\` 매개변수로 다양한 사용처(60/70/54) 흡수. CustomAlert 내부 primary 버튼도 동일 컴포넌트 사용.
- **\`dismissKeyboardOnTap\`** (View extension) — 빈 영역 탭 시 \`resignFirstResponder\`. 4개 입력 화면에 일괄 적용.

### 온보딩 푸시 체인

```
CredentialLogin
 ├─ 회원가입 ─→ Signup ─→ TermsAgreement ─→ GuardianStatus
 │              └ 로그인 하러가기/뒤로가기 → 회원가입 데이터 폐기 + 복귀
 │              └ TermsAgreement X → 회원가입 데이터 폐기 + 복귀
 └─ 아이디·비밀번호 찾기 ─→ FindAccount ─→ VerificationCode
                                    └ 인증 성공 alert \"로그인 하러가기\" → 복귀
```

\`@Presents + PresentationAction + .ifLet\` 컨벤션 그대로 사용.

### 일관성 보강

- 모든 입력 화면에 \`.dismissKeyboardOnTap()\` 적용
- ScrollView가 있는 화면(Signup, VerificationCode)에 \`.scrollDismissesKeyboard(.interactively)\` 추가
- 누락됐던 \`.background(Color.gray50)\` (Signup/TermsAgreement/GuardianStatus) 보강 — 다크모드 영향 제거
- Signup 뒤로가기 버튼이 빈 클로저였던 것 → \`store.send(.backButtonTapped)\` 연결, 회원가입 작성 데이터 폐기 + 로그인 복귀
- Tutorial / CredentialLogin / FindAccount / VerificationCode / SignUpBottomView · CustomAlert 내부 primary 버튼들을 모두 \`PrimaryButton\`으로 교체
- \`InputField\`에 \`placeholderColor\` 매개변수, 입력 텍스트 색상(\`gray900\`) 명시 — 다크모드/시스템 톤 영향 제거

## 변경 레이어

- [ ] App
- [x] Feature
- [ ] Domain
- [ ] Core
- [x] Shared

## 체크리스트

- [x] 빌드 확인 (\`xcodebuild build · test\` SUCCEEDED — FeatureOnboarding · iPhone 17 Pro 시뮬레이터)
- [x] 관련 테스트 추가/수정 (27개 PASS)
- [x] 셀프 리뷰 완료

## Reference

- TCA \`@DependencyClient\` / \`TestClock\` 패턴 — https://pointfreeco.github.io/swift-composable-architecture/
- iOS oneTimeCode 자동완성 — \`textContentType(.oneTimeCode)\`